### PR TITLE
CDRIVER-20: Not-null-terminated string support

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -503,25 +503,33 @@ bson_buffer * bson_append_undefined( bson_buffer * b , const char * name ){
     if ( ! bson_append_estart( b , bson_undefined , name , 0 ) ) return 0;
     return b;
 }
-bson_buffer * bson_append_string_base( bson_buffer * b , const char * name , const char * value , bson_type type){
-    int sl = strlen( value ) + 1;
+bson_buffer * bson_append_string_base( bson_buffer * b , const char * name , const char * value , int len , bson_type type){
+    int sl = len + 1;
     if ( ! bson_append_estart( b , type , name , 4 + sl ) ) return 0;
     bson_append32( b , &sl);
     bson_append( b , value , sl );
     return b;
 }
 bson_buffer * bson_append_string( bson_buffer * b , const char * name , const char * value ){
-    return bson_append_string_base(b, name, value, bson_string);
+    return bson_append_string_base(b, name, value, strlen ( value ), bson_string);
 }
 bson_buffer * bson_append_symbol( bson_buffer * b , const char * name , const char * value ){
-    return bson_append_string_base(b, name, value, bson_symbol);
+    return bson_append_string_base(b, name, value, strlen ( value ), bson_symbol);
 }
 bson_buffer * bson_append_code( bson_buffer * b , const char * name , const char * value ){
-    return bson_append_string_base(b, name, value, bson_code);
+    return bson_append_string_base(b, name, value, strlen ( value ), bson_code);
 }
-
-bson_buffer * bson_append_code_w_scope( bson_buffer * b , const char * name , const char * code , const bson * scope){
-    int sl = strlen(code) + 1;
+bson_buffer * bson_append_string_n( bson_buffer * b , const char * name , const char * value , int len ){
+    return bson_append_string_base(b, name, value, len, bson_string);
+}
+bson_buffer * bson_append_symbol_n( bson_buffer * b , const char * name , const char * value , int len ){
+    return bson_append_string_base(b, name, value, len, bson_symbol);
+}
+bson_buffer * bson_append_code_n( bson_buffer * b , const char * name , const char * value , int len ){
+    return bson_append_string_base(b, name, value, len, bson_code);
+}
+bson_buffer * bson_append_code_w_scope_n( bson_buffer * b , const char * name , const char * code , int len , const bson * scope){
+    int sl = len + 1;
     int size = 4 + 4 + sl + bson_size(scope);
     if (!bson_append_estart(b, bson_codewscope, name, size)) return 0;
     bson_append32(b, &size);
@@ -529,6 +537,9 @@ bson_buffer * bson_append_code_w_scope( bson_buffer * b , const char * name , co
     bson_append(b, code, sl);
     bson_append(b, scope->data, bson_size(scope));
     return b;
+}
+bson_buffer * bson_append_code_w_scope( bson_buffer * b , const char * name , const char * code , const bson * scope){
+    return bson_append_code_w_scope_n( b, name, code, strlen ( code ), scope );
 }
 
 bson_buffer * bson_append_binary( bson_buffer * b, const char * name, char type, const char * str, int len ){

--- a/src/bson.c
+++ b/src/bson.c
@@ -507,7 +507,8 @@ bson_buffer * bson_append_string_base( bson_buffer * b , const char * name , con
     int sl = len + 1;
     if ( ! bson_append_estart( b , type , name , 4 + sl ) ) return 0;
     bson_append32( b , &sl);
-    bson_append( b , value , sl );
+    bson_append( b , value , sl - 1 );
+    bson_append( b , "\0" , 1 );
     return b;
 }
 bson_buffer * bson_append_string( bson_buffer * b , const char * name , const char * value ){

--- a/src/bson.h
+++ b/src/bson.h
@@ -179,9 +179,13 @@ bson_buffer * bson_append_int( bson_buffer * b , const char * name , const int i
 bson_buffer * bson_append_long( bson_buffer * b , const char * name , const int64_t i );
 bson_buffer * bson_append_double( bson_buffer * b , const char * name , const double d );
 bson_buffer * bson_append_string( bson_buffer * b , const char * name , const char * str );
+bson_buffer * bson_append_string_n( bson_buffer * b, const char * name, const char * str , int len);
 bson_buffer * bson_append_symbol( bson_buffer * b , const char * name , const char * str );
+bson_buffer * bson_append_symbol_n( bson_buffer * b , const char * name , const char * str , int len );
 bson_buffer * bson_append_code( bson_buffer * b , const char * name , const char * str );
+bson_buffer * bson_append_code_n( bson_buffer * b , const char * name , const char * str , int len );
 bson_buffer * bson_append_code_w_scope( bson_buffer * b , const char * name , const char * code , const bson * scope);
+bson_buffer * bson_append_code_w_scope_n( bson_buffer * b , const char * name , const char * code , int size , const bson * scope);
 bson_buffer * bson_append_binary( bson_buffer * b, const char * name, char type, const char * str, int len );
 bson_buffer * bson_append_bool( bson_buffer * b , const char * name , const bson_bool_t v );
 bson_buffer * bson_append_null( bson_buffer * b , const char * name );

--- a/test/all_types.c
+++ b/test/all_types.c
@@ -19,6 +19,7 @@ int main(){
     bson_buffer_init(&bb);
     bson_append_double(&bb, "d", 3.14);
     bson_append_string(&bb, "s", "hello");
+    bson_append_string_n(&bb, "s_n", "goodbye cruel world", 7);
 
     {
         bson_buffer *obj = bson_append_start_object(&bb, "o");
@@ -40,7 +41,9 @@ int main(){
     bson_append_regex(&bb, "r", "^asdf", "imx");
     /* no dbref test (deprecated) */
     bson_append_code(&bb, "c", "function(){}");
+    bson_append_code_n(&bb, "c_n", "function(){}garbage", 12);
     bson_append_symbol(&bb, "symbol", "SYMBOL");
+    bson_append_symbol_n(&bb, "symbol_n", "SYMBOL and garbage", 6);
 
     {
         char hex[30];
@@ -74,6 +77,12 @@ int main(){
     ASSERT(bson_iterator_type(&it) == bson_string);
     ASSERT(!strcmp(bson_iterator_key(&it), "s"));
     ASSERT(!strcmp(bson_iterator_string(&it), "hello"));
+
+    ASSERT(bson_iterator_more(&it));
+    ASSERT(bson_iterator_next(&it) == bson_string);
+    ASSERT(bson_iterator_type(&it) == bson_string);
+    ASSERT(!strcmp(bson_iterator_key(&it), "s_n"));
+    ASSERT(!strcmp(bson_iterator_string(&it), "goodbye"));
 
     ASSERT(bson_iterator_more(&it));
     ASSERT(bson_iterator_next(&it) == bson_object);
@@ -151,9 +160,22 @@ int main(){
     ASSERT(!strcmp(bson_iterator_code(&it), "function(){}"));
 
     ASSERT(bson_iterator_more(&it));
+    ASSERT(bson_iterator_next(&it) == bson_code);
+    ASSERT(bson_iterator_type(&it) == bson_code);
+    ASSERT(!strcmp(bson_iterator_key(&it), "c_n"));
+    ASSERT(!strcmp(bson_iterator_string(&it), "function(){}"));
+    ASSERT(!strcmp(bson_iterator_code(&it), "function(){}"));
+
+    ASSERT(bson_iterator_more(&it));
     ASSERT(bson_iterator_next(&it) == bson_symbol);
     ASSERT(bson_iterator_type(&it) == bson_symbol);
     ASSERT(!strcmp(bson_iterator_key(&it), "symbol"));
+    ASSERT(!strcmp(bson_iterator_string(&it), "SYMBOL"));
+
+    ASSERT(bson_iterator_more(&it));
+    ASSERT(bson_iterator_next(&it) == bson_symbol);
+    ASSERT(bson_iterator_type(&it) == bson_symbol);
+    ASSERT(!strcmp(bson_iterator_key(&it), "symbol_n"));
     ASSERT(!strcmp(bson_iterator_string(&it), "SYMBOL"));
 
     ASSERT(bson_iterator_more(&it));


### PR DESCRIPTION
Added _append_n variants for those bson append functions where it made sense, along with test cases, as requested in CDRIVER-20.
