### PR TITLE
servname not supported for ai_socktype

### DIFF
--- a/src/mongo.c
+++ b/src/mongo.c
@@ -134,6 +134,7 @@ static int mongo_socket_connect( mongo_connection * conn, const char * host, int
 
     memset( &hints, 0, sizeof( hints ) );
     hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
 
     sprintf( port_str, "%d", port );
 


### PR DESCRIPTION
I had been getting this error over and over when using _MONGO_USE_GETADDRINFO. The problem was hint wasn't initializing ai_socktype. To avoid getting "servname not supported for ai_socktype" in certain systems I suggest adding this patch.
