### PR TITLE
assign 'soname' in separate environments for libbson and libmongoc

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -128,12 +128,19 @@ m = env.Library( "mongoc" ,  mLibFiles )
 b = env.Library( "bson" , bLibFiles  )
 env.Default( env.Alias( "lib" , [ m[0] , b[0] ] ) )
 
-if os.sys.platform == "linux2":
-    env.Append( SHLINKFLAGS="-shared -Wl,-soname,libmongoc.so." + VERSION )
-    env.Append( SHLINKFLAGS = "-shared -Wl,-soname,libbson.so." + VERSION )
+# build the objects explicitly so that shared targets use the same
+# environment (otherwise scons complains)
+mSharedObjs = env.SharedObject(mLibFiles)
+bSharedObjs = env.SharedObject(bLibFiles)
 
-dynm = env.SharedLibrary( "mongoc" , mLibFiles )
-dynb = env.SharedLibrary( "bson" , bLibFiles )
+bsonEnv = env.Clone()
+if os.sys.platform == "linux2":
+    env.Append( SHLINKFLAGS = "-shared -Wl,-soname,libmongoc.so." + VERSION )
+    bsonEnv.Append( SHLINKFLAGS = "-shared -Wl,-soname,libbson.so." + VERSION )
+
+dynm = env.SharedLibrary( "mongoc" , mSharedObjs )
+dynb = bsonEnv.SharedLibrary( "bson" , bSharedObjs )
+
 env.Default( env.Alias( "sharedlib" , [ dynm[0] , dynb[0] ] ) )
 
 


### PR DESCRIPTION
In the current implementation, the '-soname' parameters are both appended to the same env.  As a result, you get a build step for libmongoc.so that looks like this:

```
gcc -o libmongoc.so -shared -shared -Wl,-soname,libmongoc.so.0.4 -shared -Wl,-soname,libbson.so.0.4 src/md5.os src/mongo.os src/net.os src/gridfs.os src/bson.os src/numbers.os src/encoding.os -L/opt/local/lib
```

and libmongoc thinks it's libbson.  binaries linking against it get pretty confused.
