### PR TITLE
getaddrinfo fixes

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -61,7 +61,7 @@ env.AlwaysBuild("docs")
 # ---- Platforms ----
 PLATFORM_TEST_DIR = None
 if "LINUX" == GetOption('compile_platform'):
-    env.Append( CPPFLAGS=" -D_MONGO_USE_LINUX_SYSTEM" )
+    env.Append( CPPFLAGS=" -D_MONGO_USE_LINUX_SYSTEM -D_POSIX_SOURCE" )
     NET_LIB = "src/platform/linux/net.c"
     PLATFORM_TEST_DIR = "test/platform/linux/"
     PLATFORM_TESTS = [ "timeouts" ]

--- a/src/platform/linux/net.c
+++ b/src/platform/linux/net.c
@@ -124,7 +124,7 @@ int mongo_socket_connect( mongo *conn, const char *host, int port ) {
     if( mongo_create_socket( conn ) != MONGO_OK )
         return MONGO_ERROR;
 
-    if( getaddrinfo( host, port_str, &hints, &addrs ) != 0 ) {
+    if( (ret = getaddrinfo( host, port_str, &hints, &addrs )) != 0 ) {
         bson_errprintf( "getaddrinfo failed: %s", gai_strerror( ret ) );
         conn->err = MONGO_CONN_ADDR_FAIL;
         return MONGO_ERROR;
@@ -134,7 +134,7 @@ int mongo_socket_connect( mongo *conn, const char *host, int port ) {
         mongo_close_socket( conn->sock );
         freeaddrinfo( addrs );
         conn->err = MONGO_CONN_FAIL;
-        return MONGO_ERROR:
+        return MONGO_ERROR;
     }
 
     setsockopt( conn->sock, IPPROTO_TCP, TCP_NODELAY, ( char * )&flag, sizeof( flag ) );

--- a/src/platform/linux/net.h
+++ b/src/platform/linux/net.h
@@ -33,6 +33,7 @@
 #include <netinet/tcp.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <unistd.h>
 #define mongo_close_socket(sock) ( close(sock) )
 
 #if defined(_XOPEN_SOURCE) || defined(_POSIX_SOURCE) || _POSIX_C_SOURCE >= 1


### PR DESCRIPTION
Fix a couple minor issues to allow use of `getaddrinfo` (and therefore hostnames instead of IPs) on linux.

Wasn't sure if defaulting to `_POSIX_SOURCE` when using linux was appropriate or if there was a different expectation for incorporating the `getaddrinfo` code.  So I put it in a separate commit that you can ignore.
