### PR TITLE
Fixes warning on Clang 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 *.pyc
 *.swp
 
+.DS_Store
+
 test_*
 benchmark
 benchmark.exe

--- a/src/bson.c
+++ b/src/bson.c
@@ -585,22 +585,22 @@ void bson_init_size( bson *b, int size ) {
     _bson_init_size( b, size );
 }
 
-void bson_append_byte( bson *b, char c ) {
+static void bson_append_byte( bson *b, char c ) {
     b->cur[0] = c;
     b->cur++;
 }
 
-void bson_append( bson *b, const void *data, int len ) {
+static void bson_append( bson *b, const void *data, int len ) {
     memcpy( b->cur , data , len );
     b->cur += len;
 }
 
-void bson_append32( bson *b, const void *data ) {
+static void bson_append32( bson *b, const void *data ) {
     bson_little_endian32( b->cur, data );
     b->cur += 4;
 }
 
-void bson_append64( bson *b, const void *data ) {
+static void bson_append64( bson *b, const void *data ) {
     bson_little_endian64( b->cur, data );
     b->cur += 8;
 }
@@ -725,7 +725,7 @@ int bson_append_undefined( bson *b, const char *name ) {
     return BSON_OK;
 }
 
-int bson_append_string_base( bson *b, const char *name,
+static int bson_append_string_base( bson *b, const char *name,
                              const char *value, int len, bson_type type ) {
 
     int sl = len + 1;


### PR DESCRIPTION
Hello,

I uses bson format for my mobile game library and end up using this code to encode and decode the BSON. I cleaned up the codes so it will compile without warning on clang 3 and added some exclusion on .gitignore. It runs ok without any crash at the moment.

Thanks.
