### PR TITLE
Ignoring SIGPIPE, getaddrinfo bug and FO problem fix

### DIFF
--- a/src/mongo.c
+++ b/src/mongo.c
@@ -342,14 +342,11 @@ int mongo_replset_connect( mongo *conn ) {
     node = conn->replset->seeds;
     while( node != NULL ) {
         res = mongo_socket_connect( conn, ( const char * )&node->host, node->port );
-        if( res != MONGO_OK )
-            return MONGO_ERROR;
-
-        mongo_replset_check_seed( conn );
-
-        if( conn->replset->hosts )
-            break;
-
+        if( res == MONGO_OK ) {
+            mongo_replset_check_seed( conn );
+            if( conn->replset->hosts )
+                break;
+        }
         node = node->next;
     }
 

--- a/src/net.c
+++ b/src/net.c
@@ -17,13 +17,18 @@
 
 /* Implementation for generic version of net.h */
 #include "net.h"
+#include <errno.h>
 #include <string.h>
 
 int mongo_write_socket( mongo *conn, const void *buf, int len ) {
     const char *cbuf = buf;
+    int flags = MSG_NOSIGNAL;
+
     while ( len ) {
-        int sent = send( conn->sock, cbuf, len, 0 );
+        int sent = send( conn->sock, cbuf, len, flags );
         if ( sent == -1 ) {
+            if (errno == EPIPE) 
+                conn->connected = 0;
             conn->err = MONGO_IO_ERROR;
             return MONGO_ERROR;
         }


### PR DESCRIPTION
Ignoreing SIGPIPE, user programs can handle the socket error which is occurred by connection close without catching the signal. I think it is appropriate modification.
Another commit fixes the bug which is occurred by the wrong argument of getaddrinfo function. The original source does not use port number. This commit is related to the pull request #17.
