### PR TITLE
Allow failed seed in replica set

### DIFF
--- a/src/mongo.c
+++ b/src/mongo.c
@@ -342,6 +342,8 @@ int mongo_replset_connect( mongo *conn ) {
     node = conn->replset->seeds;
     while( node != NULL ) {
         res = mongo_socket_connect( conn, ( const char * )&node->host, node->port );
+        node = node->next;
+
         if( res != MONGO_OK )
             /* keep looking for the host list, even if a seed is not responding */
             continue;
@@ -350,8 +352,6 @@ int mongo_replset_connect( mongo *conn ) {
 
         if( conn->replset->hosts )
             break;
-
-        node = node->next;
     }
 
     /* Iterate over the host list, checking for the primary node. */

--- a/src/mongo.c
+++ b/src/mongo.c
@@ -343,7 +343,8 @@ int mongo_replset_connect( mongo *conn ) {
     while( node != NULL ) {
         res = mongo_socket_connect( conn, ( const char * )&node->host, node->port );
         if( res != MONGO_OK )
-            return MONGO_ERROR;
+            /* keep looking for the host list, even if a seed is not responding */
+            continue;
 
         mongo_replset_check_seed( conn );
 


### PR DESCRIPTION
If one of the seed hosts is down, keep trying the others to get the list of hosts in the set.

I'm not 100% certain this approach is aligned with the design intent of replica sets, but it makes sense to me.  I definitely don't want a single failing node to keep my other services from functioning.
