### PR TITLE
design proposal: return empty string if none of the "string-string" types applies in bson_iterator_string

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -527,7 +527,13 @@ MONGO_EXPORT bson_bool_t bson_iterator_bool( const bson_iterator *i ) {
 }
 
 MONGO_EXPORT const char *bson_iterator_string( const bson_iterator *i ) {
-    return bson_iterator_value( i ) + 4;
+    switch ( bson_iterator_type( i ) ) {
+    case BSON_STRING:
+    case BSON_SYMBOL:
+        return bson_iterator_value( i ) + 4;
+    default:
+        return "";
+    }
 }
 
 int bson_iterator_string_len( const bson_iterator *i ) {


### PR DESCRIPTION
Apparently this would have better been placed in a forum, mailing-list or anything alike. As I was too dumb to find any opportunity like this if it exists, I decided to place it here.

As it seems regarding bson_iterators the bson API offers accessor functions in two variations.
- those potentially returning garbage on the attempt to acces a values of inapropriate type,
  recognizable by a trailing _raw appended as suffix.
  bson_iterator_bool_raw, bson_iterator_int_raw, ... and the like
- secondly something like "safe" functions returning at least some kind of usable value,
  labeled without any suffix like the one mentioned before:
  bson_iterator_raw, bson_interator_int, .... to name just a few.

I'm quite conscious about the fact, that it is just a matter of taste, but at least in my opinion it could add to the felt consistency of the API if bson_iterator_string would conform to the naming pattern used in the other accessor functions.
