### PR TITLE
Change to support connect secondaries in replica setup and take options for mongo_find_one.

### DIFF
--- a/src/gridfs.c
+++ b/src/gridfs.c
@@ -423,7 +423,7 @@ int gridfs_find_query( gridfs *gfs, bson *query,
     bson_finish( &finalQuery );
 
     i = ( mongo_find_one( gfs->client, gfs->files_ns,
-                          &finalQuery, NULL, &out ) == MONGO_OK );
+                          &finalQuery, NULL, &out, 0 ) == MONGO_OK );
     bson_destroy( &uploadDate );
     bson_destroy( &finalQuery );
     if ( !i )
@@ -579,7 +579,7 @@ MONGO_EXPORT void gridfile_get_chunk( gridfile *gfile, int n, bson* out ) {
 
     result = (mongo_find_one(gfile->gfs->client,
                              gfile->gfs->chunks_ns,
-                             &query, NULL, out ) == MONGO_OK );
+                             &query, NULL, out, 0 ) == MONGO_OK );
     bson_destroy( &query );
     if (!result) {
         bson empty;

--- a/src/mongo.c
+++ b/src/mongo.c
@@ -258,10 +258,7 @@ MONGO_EXPORT int mongo_connect( mongo *conn , const char *host, int port ) {
     if( mongo_socket_connect( conn, host, port ) != MONGO_OK )
         return MONGO_ERROR;
 
-    if( mongo_check_is_master( conn ) != MONGO_OK )
-        return MONGO_ERROR;
-    else
-        return MONGO_OK;
+    return MONGO_OK;
 }
 
 MONGO_EXPORT void mongo_replset_init( mongo *conn, const char *name ) {
@@ -851,13 +848,14 @@ MONGO_EXPORT mongo_cursor *mongo_find( mongo *conn, const char *ns, bson *query,
 }
 
 MONGO_EXPORT int mongo_find_one( mongo *conn, const char *ns, bson *query,
-                    bson *fields, bson *out ) {
+                    bson *fields, bson *out, int options ) {
 
     mongo_cursor cursor[1];
     mongo_cursor_init( cursor, conn, ns );
     mongo_cursor_set_query( cursor, query );
     mongo_cursor_set_fields( cursor, fields );
     mongo_cursor_set_limit( cursor, 1 );
+    mongo_cursor_set_options( cursor, options );
 
     if ( mongo_cursor_next( cursor ) == MONGO_OK ) {
         bson_init_size( out, bson_size( (bson *)&cursor->current ) );
@@ -1080,7 +1078,7 @@ MONGO_EXPORT int mongo_run_command( mongo *conn, const char *db, bson *command,
     strcpy( ns, db );
     strcpy( ns+sl, ".$cmd" );
 
-    res = mongo_find_one( conn, ns, command, bson_empty( &fields ), &response );
+    res = mongo_find_one( conn, ns, command, bson_empty( &fields ), &response, 0 );
     bson_free( ns );
 
     if( res != MONGO_OK )

--- a/src/mongo.h
+++ b/src/mongo.h
@@ -480,11 +480,12 @@ MONGO_EXPORT int mongo_cursor_destroy( mongo_cursor *cursor );
  * @param query the bson query.
  * @param fields a bson document of the fields to be returned.
  * @param out a bson document in which to put the query result.
+ * @param options a bitfield containing cursor options.
  *
  */
 /* out can be NULL if you don't care about results. useful for commands */
 MONGO_EXPORT bson_bool_t mongo_find_one( mongo *conn, const char *ns, bson *query,
-                            bson *fields, bson *out );
+                                         bson *fields, bson *out, int options );
 
 /* MongoDB Helper Functions */
 

--- a/test/benchmark.c
+++ b/test/benchmark.c
@@ -240,7 +240,7 @@ static void find_one( const char *ns ) {
     int i;
     for ( i=0; i < PER_TRIAL; i++ ) {
         make_query( &b );
-        ASSERT( mongo_find_one( conn, ns, &b, NULL, NULL ) == MONGO_OK );
+        ASSERT( mongo_find_one( conn, ns, &b, NULL, NULL, 0 ) == MONGO_OK );
         bson_destroy( &b );
     }
 }

--- a/test/errors.c
+++ b/test/errors.c
@@ -50,7 +50,7 @@ int main() {
     bson_destroy( &obj );
 
     /* should clear lasterror but not preverror */
-    mongo_find_one( conn, ns, bson_empty( &obj ), bson_empty( &obj ), NULL );
+    mongo_find_one( conn, ns, bson_empty( &obj ), bson_empty( &obj ), NULL, 0 );
 
     ASSERT( mongo_cmd_get_prev_error( conn, db, NULL ) == MONGO_ERROR );
     ASSERT( mongo_cmd_get_last_error( conn, db, NULL ) == MONGO_OK );

--- a/test/helpers.c
+++ b/test/helpers.c
@@ -27,7 +27,7 @@ void test_index_helper( mongo *conn ) {
 
     bson_finish( &b );
 
-    mongo_find_one( conn, "test.system.indexes", &b, NULL, &out );
+    mongo_find_one( conn, "test.system.indexes", &b, NULL, &out, 0 );
 
     bson_print( &out );
 

--- a/test/replica_set.c
+++ b/test/replica_set.c
@@ -58,7 +58,7 @@ int test_reconnect( const char *set_name ) {
         sleep( 10 );
         e = 1;
         do {
-            res = mongo_find_one( conn, "foo.bar", bson_empty( &b ), bson_empty( &b ), NULL );
+            res = mongo_find_one( conn, "foo.bar", bson_empty( &b ), bson_empty( &b ), NULL, 0 );
             if( res == MONGO_ERROR && conn->err == MONGO_IO_ERROR ) {
                 sleep( 2 );
                 if( e++ < 30 ) {

--- a/test/simple.c
+++ b/test/simple.c
@@ -68,7 +68,7 @@ int main() {
     }
 
     mongo_cmd_drop_collection( conn, "test", col, NULL );
-    mongo_find_one( conn, ns, bson_empty( &b ), bson_empty( &b ), NULL );
+    mongo_find_one( conn, ns, bson_empty( &b ), bson_empty( &b ), NULL, 0 );
 
     for( i=0; i< 5; i++ ) {
         bson_init( &b );

--- a/test/update.c
+++ b/test/update.c
@@ -22,7 +22,7 @@ int main() {
 
     /* if the collection doesn't exist dropping it will fail */
     if ( mongo_cmd_drop_collection( conn, "test", col, NULL ) == MONGO_OK
-            && mongo_find_one( conn, ns, bson_empty( &obj ), bson_empty( &obj ), NULL ) != MONGO_OK ) {
+            && mongo_find_one( conn, ns, bson_empty( &obj ), bson_empty( &obj ), NULL, 0 ) != MONGO_OK ) {
         printf( "failed to drop collection\n" );
         exit( 1 );
     }
@@ -67,7 +67,7 @@ int main() {
         bson_destroy( &op );
     }
 
-    if( mongo_find_one( conn, ns, &cond, 0, &obj ) != MONGO_OK ) {
+    if( mongo_find_one( conn, ns, &cond, 0, &obj, 0 ) != MONGO_OK ) {
         printf( "Failed to find object\n" );
         exit( 1 );
     } else {


### PR DESCRIPTION
With this change we can connect to secondary servers in replica setup and read from them using SLAVE_OK, query option. Also added options parameter for mongo_find_one to use it with SLAVE_OK.
