### PR TITLE
Add const qualifiers to bson * on cursor and other query inputs

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -110,7 +110,7 @@ MONGO_EXPORT int bson_buffer_size( const bson *b ) {
 }
 
 
-const char *bson_data( bson *b ) {
+const char *bson_data( const bson *b ) {
     return (const char *)b->data;
 }
 
@@ -216,7 +216,7 @@ time_t bson_oid_generated_time( bson_oid_t *oid ) {
     return out;
 }
 
-void bson_print( bson *b ) {
+void bson_print( const bson *b ) {
     bson_print_raw( b->data , 0 );
 }
 

--- a/src/bson.h
+++ b/src/bson.h
@@ -129,14 +129,14 @@ MONGO_EXPORT int bson_buffer_size( const bson *b );
  *
  * @param b the BSON object to print.
  */
-void bson_print( bson *b );
+void bson_print( const bson *b );
 
 /**
  * Return a pointer to the raw buffer stored by this bson object.
  *
  * @param b a BSON object
  */
-const char *bson_data( bson *b );
+const char *bson_data( const bson *b );
 
 /**
  * Print a string representation of a BSON object.

--- a/src/mongo.c
+++ b/src/mongo.c
@@ -548,7 +548,7 @@ MONGO_EXPORT void mongo_destroy( mongo *conn ) {
 }
 
 /* Determine whether this BSON object is valid for the given operation.  */
-static int mongo_bson_valid( mongo *conn, bson *bson, int write ) {
+static int mongo_bson_valid( mongo *conn, const bson *bson, int write ) {
     if( ! bson->finished ) {
         conn->err = MONGO_BSON_NOT_FINISHED;
         return MONGO_ERROR;
@@ -576,7 +576,7 @@ static int mongo_bson_valid( mongo *conn, bson *bson, int write ) {
 }
 
 /* Determine whether this BSON object is valid for the given operation.  */
-static int mongo_cursor_bson_valid( mongo_cursor *cursor, bson *bson ) {
+static int mongo_cursor_bson_valid( mongo_cursor *cursor, const bson *bson ) {
     if( ! bson->finished ) {
         cursor->err = MONGO_CURSOR_BSON_ERROR;
         cursor->conn->err = MONGO_BSON_NOT_FINISHED;
@@ -595,7 +595,7 @@ static int mongo_cursor_bson_valid( mongo_cursor *cursor, bson *bson ) {
 /* MongoDB CRUD API */
 
 MONGO_EXPORT int mongo_insert_batch( mongo *conn, const char *ns,
-                        bson **bsons, int count ) {
+                        const bson **bsons, int count ) {
 
     int size =  16 + 4 + strlen( ns ) + 1;
     int i;
@@ -621,7 +621,7 @@ MONGO_EXPORT int mongo_insert_batch( mongo *conn, const char *ns,
     return mongo_message_send( conn, mm );
 }
 
-MONGO_EXPORT int mongo_insert( mongo *conn , const char *ns , bson *bson ) {
+MONGO_EXPORT int mongo_insert( mongo *conn , const char *ns , const bson *bson ) {
 
     char *data;
     mongo_message *mm;
@@ -829,8 +829,8 @@ static int mongo_cursor_get_more( mongo_cursor *cursor ) {
     }
 }
 
-MONGO_EXPORT mongo_cursor *mongo_find( mongo *conn, const char *ns, bson *query,
-                          bson *fields, int limit, int skip, int options ) {
+MONGO_EXPORT mongo_cursor *mongo_find( mongo *conn, const char *ns, const bson *query,
+                          const bson *fields, int limit, int skip, int options ) {
 
     mongo_cursor *cursor = ( mongo_cursor * )bson_malloc( sizeof( mongo_cursor ) );
     mongo_cursor_init( cursor, conn, ns );
@@ -850,8 +850,8 @@ MONGO_EXPORT mongo_cursor *mongo_find( mongo *conn, const char *ns, bson *query,
     }
 }
 
-MONGO_EXPORT int mongo_find_one( mongo *conn, const char *ns, bson *query,
-                    bson *fields, bson *out ) {
+MONGO_EXPORT int mongo_find_one( mongo *conn, const char *ns, const bson *query,
+                    const bson *fields, bson *out ) {
 
     mongo_cursor cursor[1];
     mongo_cursor_init( cursor, conn, ns );
@@ -880,11 +880,11 @@ void mongo_cursor_init( mongo_cursor *cursor, mongo *conn, const char *ns ) {
     cursor->current.data = NULL;
 }
 
-void mongo_cursor_set_query( mongo_cursor *cursor, bson *query ) {
+void mongo_cursor_set_query( mongo_cursor *cursor, const bson *query ) {
     cursor->query = query;
 }
 
-void mongo_cursor_set_fields( mongo_cursor *cursor, bson *fields ) {
+void mongo_cursor_set_fields( mongo_cursor *cursor, const bson *fields ) {
     cursor->fields = fields;
 }
 
@@ -993,7 +993,7 @@ MONGO_EXPORT int mongo_cursor_destroy( mongo_cursor *cursor ) {
 
 /* MongoDB Helper Functions */
 
-MONGO_EXPORT int mongo_create_index( mongo *conn, const char *ns, bson *key, int options, bson *out ) {
+MONGO_EXPORT int mongo_create_index( mongo *conn, const char *ns, const bson *key, int options, bson *out ) {
     bson b;
     bson_iterator it;
     char name[255] = {'_'};
@@ -1043,7 +1043,7 @@ bson_bool_t mongo_create_simple_index( mongo *conn, const char *ns, const char *
     return success;
 }
 
-MONGO_EXPORT double mongo_count( mongo *conn, const char *db, const char *ns, bson *query ) {
+MONGO_EXPORT double mongo_count( mongo *conn, const char *db, const char *ns, const bson *query ) {
     bson cmd;
     bson out = {NULL, 0};
     double count = -1;
@@ -1068,7 +1068,7 @@ MONGO_EXPORT double mongo_count( mongo *conn, const char *db, const char *ns, bs
     }
 }
 
-MONGO_EXPORT int mongo_run_command( mongo *conn, const char *db, bson *command,
+MONGO_EXPORT int mongo_run_command( mongo *conn, const char *db, const bson *command,
                        bson *out ) {
 
     bson response = {NULL, 0};

--- a/src/mongo.h
+++ b/src/mongo.h
@@ -160,8 +160,8 @@ typedef struct {
     int seen;          /**< Number returned so far. */
     bson current;      /**< This cursor's current bson object. */
     mongo_cursor_error_t err; /**< Errors on this cursor. */
-    bson *query;       /**< Bitfield containing cursor options. */
-    bson *fields;      /**< Bitfield containing cursor options. */
+    const bson *query; /**< Bitfield containing cursor options. */
+    const bson *fields;/**< Bitfield containing cursor options. */
     int options;       /**< Bitfield containing cursor options. */
     int limit;         /**< Bitfield containing cursor options. */
     int skip;          /**< Bitfield containing cursor options. */
@@ -316,7 +316,7 @@ MONGO_EXPORT void mongo_destroy( mongo *conn );
  *     field is MONGO_BSON_INVALID, check the err field
  *     on the bson struct for the reason.
  */
-MONGO_EXPORT int mongo_insert( mongo *conn, const char *ns, bson *data );
+MONGO_EXPORT int mongo_insert( mongo *conn, const char *ns, const bson *data );
 
 /**
  * Insert a batch of BSON documents into a MongoDB server. This function
@@ -331,7 +331,7 @@ MONGO_EXPORT int mongo_insert( mongo *conn, const char *ns, bson *data );
  *
  */
 MONGO_EXPORT int mongo_insert_batch( mongo *conn , const char *ns ,
-                        bson **data , int num );
+                        const bson **data , int num );
 
 /**
  * Update a document in a MongoDB server.
@@ -374,8 +374,8 @@ MONGO_EXPORT int mongo_remove( mongo *conn, const char *ns, const bson *cond );
  *     an error has occurred. For finer-grained error checking,
  *     use the cursor builder API instead.
  */
-MONGO_EXPORT mongo_cursor *mongo_find( mongo *conn, const char *ns, bson *query,
-                          bson *fields, int limit, int skip, int options );
+MONGO_EXPORT mongo_cursor *mongo_find( mongo *conn, const char *ns, const bson *query,
+                          const bson *fields, int limit, int skip, int options );
 
 /**
  * Initalize a new cursor object.
@@ -397,7 +397,7 @@ void mongo_cursor_init( mongo_cursor *cursor, mongo *conn, const char *ns );
  *   $query, $orderby, $hint, and/or $explain. See
  *   http://www.mongodb.org/display/DOCS/Mongo+Wire+Protocol for details.
  */
-void mongo_cursor_set_query( mongo_cursor *cursor, bson *query );
+void mongo_cursor_set_query( mongo_cursor *cursor, const bson *query );
 
 /**
  * Set the fields to return for this cursor. If you want to return
@@ -407,7 +407,7 @@ void mongo_cursor_set_query( mongo_cursor *cursor, bson *query );
  * @param fields a bson object representing the fields to return.
  *   See http://www.mongodb.org/display/DOCS/Retrieving+a+Subset+of+Fields.
  */
-void mongo_cursor_set_fields( mongo_cursor *cursor, bson *fields );
+void mongo_cursor_set_fields( mongo_cursor *cursor, const bson *fields );
 
 /**
  * Set the number of documents to skip.
@@ -483,8 +483,8 @@ MONGO_EXPORT int mongo_cursor_destroy( mongo_cursor *cursor );
  *
  */
 /* out can be NULL if you don't care about results. useful for commands */
-MONGO_EXPORT bson_bool_t mongo_find_one( mongo *conn, const char *ns, bson *query,
-                            bson *fields, bson *out );
+MONGO_EXPORT bson_bool_t mongo_find_one( mongo *conn, const char *ns, const bson *query,
+                            const bson *fields, bson *out );
 
 /* MongoDB Helper Functions */
 
@@ -500,7 +500,7 @@ MONGO_EXPORT bson_bool_t mongo_find_one( mongo *conn, const char *ns, bson *quer
  *     MONGO_ERROR is returned.
  */
 MONGO_EXPORT double mongo_count( mongo *conn, const char *db, const char *coll,
-                     bson *query );
+                     const bson *query );
 
 /**
  * Create a compouned index.
@@ -515,7 +515,7 @@ MONGO_EXPORT double mongo_count( mongo *conn, const char *db, const char *coll,
  *
  * @return MONGO_OK if index is created successfully; otherwise, MONGO_ERROR.
  */
-MONGO_EXPORT int mongo_create_index( mongo *conn, const char *ns, bson *key, int options, bson *out );
+MONGO_EXPORT int mongo_create_index( mongo *conn, const char *ns, const bson *key, int options, bson *out );
 
 /**
  * Create an index with a single key.
@@ -544,7 +544,7 @@ bson_bool_t mongo_create_simple_index( mongo *conn, const char *ns, const char *
  *
  * @return MONGO_OK if the command ran without error.
  */
-MONGO_EXPORT bson_bool_t mongo_run_command( mongo *conn, const char *db, bson *command, bson *out );
+MONGO_EXPORT bson_bool_t mongo_run_command( mongo *conn, const char *db, const bson *command, bson *out );
 
 /**
  * Run a command that accepts a simple string key and integer value.


### PR DESCRIPTION
Resubmitting from a clean branch.

This adds const qualifiers to bson \* parameters which should be const and makes query and fields const on bson_cursor.
