### PR TITLE
Remove unimplemented error string from BSON struct

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -94,7 +94,6 @@ static void _bson_reset( bson *b ) {
     b->finished = 0;
     b->stackPos = 0;
     b->err = 0;
-    b->errstr = NULL;
 }
 
 MONGO_EXPORT int bson_size( const bson *b ) {

--- a/src/bson.h
+++ b/src/bson.h
@@ -138,7 +138,6 @@ typedef struct {
     int stack[32];
     int stackPos;
     int err; /**< Bitfield representing errors or warnings on this buffer */
-    char *errstr; /**< A string representation of the most recent error or warning. */
 } bson;
 
 #pragma pack(1)


### PR DESCRIPTION
It's confusing that the struct has this 'errstr' member. It's never set to a useful value, and the comment doesn't say it's unimplemented.

(In addition, errstr points to garbage after a call to bson_empty without bson_init first.)
