### PR TITLE
Initialize errstr in bson_empty

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -65,6 +65,7 @@ bson *bson_empty( bson *obj ) {
     bson_init_data( obj, data );
     obj->finished = 1;
     obj->err = 0;
+    obj->errstr = NULL;
     obj->stackPos = 0;
     return obj;
 }


### PR DESCRIPTION
It seems like bson_empty should work even without first calling bson_init. Without this fix errstr is set to garbage in that case, which caused a bug in my debugging output.

(Mentioned here: https://github.com/mongodb/mongo-c-driver/pull/36 )
