### PR TITLE
Feature: slaveOk && DataCenter awareness

### DIFF
--- a/src/mongo.c
+++ b/src/mongo.c
@@ -564,7 +564,7 @@ static void mongo_replset_check_seed( mongo *conn ) {
 
     bson_init_size(&out,0);
 
-    if( mongo_cmd_replset_get_status(conn,&out) == MONGO_OK ){
+    if( mongo_get_replset_config(conn,&out) == MONGO_OK ){
 
         if( bson_find( &it, &out, "members" ) ) {
             data = bson_iterator_value( &it );
@@ -1886,12 +1886,12 @@ MONGO_EXPORT bson_bool_t mongo_cmd_authenticate( mongo *conn, const char *db, co
 
 
 #define REPLSET_COLLECTION_NAME "local.system.replset"
-MONGO_EXPORT int mongo_cmd_replset_get_status( mongo *conn,bson *out ) {
+MONGO_EXPORT int mongo_get_replset_config( mongo *conn,bson *out ) {
     bson response = {NULL, 0};
     bson empty;
     int sl = strlen( REPLSET_COLLECTION_NAME);
     char *ns = bson_malloc( sl + 1 ); 
-    int res, success = 0;
+    int res;
 
     strncpy( ns, REPLSET_COLLECTION_NAME , sl );
 

--- a/src/mongo.c
+++ b/src/mongo.c
@@ -715,6 +715,8 @@ static int mongo_replset_connect_measure(mongo *conn)
 				current = end - start;
 				if(current < best){
 					best = current;
+					if(conn->sock)
+						mongo_env_close_socket(conn->sock);
 					socket = conn->sock;
 					remember_primary_node(conn,node);
 					if(current < ACCEPTABLE_LATENCY)

--- a/src/mongo.h
+++ b/src/mongo.h
@@ -57,7 +57,8 @@ typedef enum mongo_error_t {
     MONGO_BSON_INVALID,      /**< BSON not valid for the specified op. */
     MONGO_BSON_NOT_FINISHED, /**< BSON object has not been finished. */
     MONGO_BSON_TOO_LARGE,    /**< BSON object exceeds max BSON size. */
-    MONGO_WRITE_CONCERN_INVALID /**< Supplied write concern object is invalid. */
+    MONGO_WRITE_CONCERN_INVALID, /**< Supplied write concern object is invalid. */
+    MONGO_UNAUTHORIZED /**< Unauthorized?*/
 } mongo_error_t;
 
 typedef enum mongo_cursor_error_t {
@@ -172,8 +173,10 @@ typedef struct mongo {
 	int max_bson_size;         /**< Largest BSON object allowed on this connection. */
 	bson_bool_t connected;     /**< Connection status. */
 	mongo_write_concern *write_concern; /**< The default write concern. */
-	char *preferred_tag;
-	char *tag_name;
+	const char *preferred_tag;       /**< DC-aware feature, the preferred tag value, caller responsible to free the memory*/
+	const char *tag_name;            /**< DC-aware feature, the tag name, caller responsible to free the memory*/
+	const char *user_name;           /**< User name used for authenticating admin db,caller responsible to free the memory*/
+	const char *password;            /**< Password used for authentitcating admin db,call responsible to free the memory*/
 
 	mongo_error_t err;          /**< Most recent driver error code. */
 	int errcode;                /**< Most recent errno or WSAGetLastError(). */

--- a/src/mongo.h
+++ b/src/mongo.h
@@ -755,7 +755,7 @@ MONGO_EXPORT int mongo_cmd_authenticate( mongo *conn, const char *db,
 /* return value is master status */
 MONGO_EXPORT bson_bool_t mongo_cmd_ismaster( mongo *conn, bson *out );
 
-MONGO_EXPORT int mongo_cmd_replset_get_status( mongo *conn, bson *out );
+MONGO_EXPORT int mongo_get_replset_config( mongo *conn, bson *out );
 
 /**
  * Get the error for the last command with the current connection.


### PR DESCRIPTION
How to use?

Before calling mongo_replset_connect,

set conn->flags = MONGO_SLAVE_OK
set conn->preferred_tag = "cloud"
set conn->tag_name = "DC"

then the host "E" will be chosen!

{
    _id : "someSet",
    members : [
        {_id : 0, host : "A", tags : {"DC": "ny"}},
        {_id : 1, host : "B", tags : {"DC": "ny"}},
        {_id : 2, host : "C", tags : {"DC": "sf"}},
        {_id : 3, host : "D", tags : {"DC": "sf"}},
        {_id : 4, host : "E", tags : {"DC": "cloud"}}
    ]
