### PR TITLE
Guard against dereferencing null pointers

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -71,7 +71,7 @@ MONGO_EXPORT bson *bson_empty( bson *obj ) {
 }
 
 MONGO_EXPORT int bson_copy( bson *out, const bson *in ) {
-    if ( !out ) return BSON_ERROR;
+    if ( !out || !in ) return BSON_ERROR;
     if ( !in->finished ) return BSON_ERROR;
     bson_init_size( out, bson_size( in ) );
     memcpy( out->data, in->data, bson_size( in ) );
@@ -815,6 +815,7 @@ MONGO_EXPORT int bson_append_code_n( bson *b, const char *name, const char *valu
 MONGO_EXPORT int bson_append_code_w_scope_n( bson *b, const char *name,
                                 const char *code, int len, const bson *scope ) {
 
+    if ( !scope ) return BSON_ERROR;
     int sl = len + 1;
     int size = 4 + 4 + sl + bson_size( scope );
     if ( bson_append_estart( b, BSON_CODEWSCOPE, name, size ) == BSON_ERROR )
@@ -875,6 +876,7 @@ MONGO_EXPORT int bson_append_regex( bson *b, const char *name, const char *patte
 }
 
 MONGO_EXPORT int bson_append_bson( bson *b, const char *name, const bson *bson ) {
+    if ( !bson ) return BSON_ERROR;
     if ( bson_append_estart( b, BSON_OBJECT, name, bson_size( bson ) ) == BSON_ERROR )
         return BSON_ERROR;
     bson_append( b , bson->data , bson_size( bson ) );


### PR DESCRIPTION
I'm using the bson part of the library in a project. Running clang's static analyzer caught a couple issues in bson.c which I've fixed in this commit.
