### PR TITLE
declare no parameters with ( void ) when a function uses no paramters

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -52,7 +52,7 @@ static int ( *oid_inc_func )( void )  = NULL;
    READING
    ------------------------------ */
 
-MONGO_EXPORT bson* bson_create() {
+MONGO_EXPORT bson* bson_create( void ) {
 	return (bson*)bson_malloc(sizeof(bson));
 }
 
@@ -274,7 +274,7 @@ MONGO_EXPORT void bson_print_raw( const char *data , int depth ) {
    ITERATOR
    ------------------------------ */
 
-MONGO_EXPORT bson_iterator* bson_iterator_create() {
+MONGO_EXPORT bson_iterator* bson_iterator_create( void ) {
     return ( bson_iterator* )malloc( sizeof( bson_iterator ) );
 }
 

--- a/src/bson.h
+++ b/src/bson.h
@@ -159,7 +159,7 @@ typedef struct {
    READING
    ------------------------------ */
 
-MONGO_EXPORT bson* bson_create();
+MONGO_EXPORT bson* bson_create( void );
 MONGO_EXPORT void  bson_dispose(bson* b);
 
 /**
@@ -206,7 +206,7 @@ MONGO_EXPORT void bson_print_raw( const char *bson , int depth );
 MONGO_EXPORT bson_type bson_find( bson_iterator *it, const bson *obj, const char *name );
 
 
-MONGO_EXPORT bson_iterator* bson_iterator_create();
+MONGO_EXPORT bson_iterator* bson_iterator_create( void );
 MONGO_EXPORT void bson_iterator_dispose(bson_iterator*);
 /**
  * Initialize a bson_iterator.

--- a/src/gridfs.c
+++ b/src/gridfs.c
@@ -21,7 +21,7 @@
 #include <string.h>
 #include <assert.h>
 
-MONGO_EXPORT gridfs* gridfs_create() {
+MONGO_EXPORT gridfs* gridfs_create( void ) {
     return (gridfs*)bson_malloc(sizeof(gridfs));
 }
 
@@ -29,7 +29,7 @@ MONGO_EXPORT void gridfs_dispose(gridfs* gfs) {
     free(gfs);
 }
 
-MONGO_EXPORT gridfile* gridfile_create() {
+MONGO_EXPORT gridfile* gridfile_create( void ) {
     return (gridfile*)bson_malloc(sizeof(gridfile));
 }
 

--- a/src/gridfs.h
+++ b/src/gridfs.h
@@ -51,9 +51,9 @@ typedef struct {
     int pending_len;    /**> Length of pending_data buffer */
 } gridfile;
 
-MONGO_EXPORT gridfs* gridfs_create();
+MONGO_EXPORT gridfs* gridfs_create( void );
 MONGO_EXPORT void gridfs_dispose(gridfs* gfs);
-MONGO_EXPORT gridfile* gridfile_create();
+MONGO_EXPORT gridfile* gridfile_create( void );
 MONGO_EXPORT void gridfile_dispose(gridfile* gf);
 MONGO_EXPORT void gridfile_get_descriptor(gridfile* gf, bson* out);
 

--- a/src/mongo.c
+++ b/src/mongo.c
@@ -24,7 +24,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-MONGO_EXPORT mongo* mongo_create() {
+MONGO_EXPORT mongo* mongo_create( void ) {
     return (mongo*)bson_malloc(sizeof(mongo));
 }
 
@@ -94,7 +94,7 @@ MONGO_EXPORT const char* mongo_get_host(mongo* conn, int i) {
 }
 
 
-MONGO_EXPORT mongo_cursor* mongo_cursor_create() {
+MONGO_EXPORT mongo_cursor* mongo_cursor_create( void ) {
     return (mongo_cursor*)bson_malloc(sizeof(mongo_cursor));
 }
 

--- a/src/mongo.h
+++ b/src/mongo.h
@@ -199,7 +199,7 @@ Connection API
 
 /** Initialize sockets for Windows.
  */
-MONGO_EXPORT void mongo_init_sockets();
+MONGO_EXPORT void mongo_init_sockets( void );
 
 /**
  * Initialize a new mongo connection object. You must initialize each mongo
@@ -788,7 +788,7 @@ MONGO_EXPORT void mongo_cmd_reset_error( mongo *conn, const char *db );
 Utility API
 **********************************************************************/
 
-MONGO_EXPORT mongo* mongo_create();
+MONGO_EXPORT mongo* mongo_create( void );
 MONGO_EXPORT void mongo_dispose(mongo* conn);
 MONGO_EXPORT int mongo_get_err(mongo* conn);
 MONGO_EXPORT int mongo_is_connected(mongo* conn);
@@ -797,7 +797,7 @@ MONGO_EXPORT const char* mongo_get_primary(mongo* conn);
 MONGO_EXPORT int mongo_get_socket(mongo* conn) ;
 MONGO_EXPORT int mongo_get_host_count(mongo* conn);
 MONGO_EXPORT const char* mongo_get_host(mongo* conn, int i);
-MONGO_EXPORT mongo_cursor* mongo_cursor_create();
+MONGO_EXPORT mongo_cursor* mongo_cursor_create( void );
 MONGO_EXPORT void mongo_cursor_dispose(mongo_cursor* cursor);
 MONGO_EXPORT int  mongo_get_server_err(mongo* conn);
 MONGO_EXPORT const char*  mongo_get_server_err_string(mongo* conn);


### PR DESCRIPTION
I think it's more explicit to always use "void" when a function use no parameter.
