### PR TITLE
Fix for Coverity 10500: deref before null check

### DIFF
--- a/src/mongo.c
+++ b/src/mongo.c
@@ -517,9 +517,9 @@ static void mongo_replset_check_seed( mongo *conn ) {
                 host_string = bson_iterator_string( &it_sub );
 
                 host_port = bson_malloc( sizeof( mongo_host_port ) );
-                mongo_parse_host( host_string, host_port );
 
                 if( host_port ) {
+                    mongo_parse_host( host_string, host_port );
                     mongo_replset_add_node( &conn->replset->hosts,
                                             host_port->host, host_port->port );
 


### PR DESCRIPTION
Please review.  (my first pull request so made it a tiny one)
