### PR TITLE
problem to compile mongo driver in 64 bits, we need to cast time_t into int to avoid a warning

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -155,7 +155,7 @@ MONGO_EXPORT void bson_oid_gen( bson_oid_t *oid ) {
     static int incr = 0;
     static int fuzz = 0;
     int i;
-    int t = time( NULL );
+    time_t t = time( NULL );
 
     if( oid_inc_func )
         i = oid_inc_func();
@@ -166,7 +166,7 @@ MONGO_EXPORT void bson_oid_gen( bson_oid_t *oid ) {
         if ( oid_fuzz_func )
             fuzz = oid_fuzz_func();
         else {
-            srand( t );
+            srand( ( int )t );
             fuzz = rand();
         }
     }


### PR DESCRIPTION
 problem to compile mongo driver in 64 bits, we need to cast time_t into int to avoid a warning
