### PR TITLE
avoid the sigpipe on OS X

### DIFF
--- a/src/env_posix.c
+++ b/src/env_posix.c
@@ -175,6 +175,13 @@ int mongo_env_socket_connect( mongo *conn, const char *host, int port ) {
             conn->sock = 0;
             continue;
         }
+#if __APPLE__
+        {
+            int flag = 1;
+            setsockopt( conn->sock, SOL_SOCKET, SO_NOSIGPIPE,
+                       ( void * ) &flag, sizeof( flag ) );
+        }
+#endif /* __APPLE__ */
 
         if ( ai_ptr->ai_protocol == IPPROTO_TCP ) {
             int flag = 1;


### PR DESCRIPTION
This causes MongoHub-Mac to crash since the sigpipe is not catched
