### PR TITLE
Fix bson_oid_generated_time for systems with a 64bit time_t.

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -177,7 +177,7 @@ MONGO_EXPORT void bson_oid_gen( bson_oid_t *oid ) {
 }
 
 MONGO_EXPORT time_t bson_oid_generated_time( bson_oid_t *oid ) {
-    int out = 0;
+    time_t out = 0;
     bson_big_endian32( &out, &oid->ints[0] );
 
     return out;

--- a/src/bson.c
+++ b/src/bson.c
@@ -177,7 +177,7 @@ MONGO_EXPORT void bson_oid_gen( bson_oid_t *oid ) {
 }
 
 MONGO_EXPORT time_t bson_oid_generated_time( bson_oid_t *oid ) {
-    time_t out;
+    int out = 0;
     bson_big_endian32( &out, &oid->ints[0] );
 
     return out;


### PR DESCRIPTION
See https://jira.mongodb.org/browse/CDRIVER-195

Not sure how to write a test for this, since the failure is OS-dependent.  Would appreciate feedback on that.
