### PR TITLE
Minor fixes

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -15,6 +15,10 @@
  *    limitations under the License.
  */
 
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -938,6 +942,8 @@ MONGO_EXPORT int bson_append_start_array( bson *b, const char *name ) {
 MONGO_EXPORT int bson_append_finish_object( bson *b ) {
     char *start;
     int i;
+    if (!b) return BSON_ERROR;
+    if (!b->stackPos) { b->err = BSON_NOT_IN_SUBOBJECT; return BSON_ERROR; }
     if ( bson_ensure_space( b, 1 ) == BSON_ERROR ) return BSON_ERROR;
     bson_append_byte( b , 0 );
 

--- a/src/bson.h
+++ b/src/bson.h
@@ -56,6 +56,7 @@
 #elif defined(MONGO_USE__INT64)
 typedef __int64 int64_t;
 typedef unsigned __int64 uint64_t;
+#define INT32_MAX 0x7fffffffL
 #elif defined(MONGO_USE_LONG_LONG_INT)
 typedef long long int int64_t;
 typedef unsigned long long int uint64_t;
@@ -81,15 +82,16 @@ MONGO_EXTERN_C_START
 #define BSON_ERROR -1
 
 enum bson_error_t {
-    BSON_SIZE_OVERFLOW = 1 /**< Trying to create a BSON object larger than INT_MAX. */
+    BSON_SIZE_OVERFLOW =     (1 << 0),  /**< Trying to create a BSON object larger than INT_MAX. */
+    BSON_ALREADY_FINISHED =  (1 << 4),  /**< Trying to modify a finished BSON object. */
+    BSON_NOT_IN_SUBOBJECT =  (1 << 5)   /**< Trying bson_append_finish_object() and not in sub */
 };
 
 enum bson_validity_t {
-    BSON_VALID = 0,                 /**< BSON is valid and UTF-8 compliant. */
-    BSON_NOT_UTF8 = ( 1<<1 ),       /**< A key or a string is not valid UTF-8. */
-    BSON_FIELD_HAS_DOT = ( 1<<2 ),  /**< Warning: key contains '.' character. */
-    BSON_FIELD_INIT_DOLLAR = ( 1<<3 ), /**< Warning: key starts with '$' character. */
-    BSON_ALREADY_FINISHED = ( 1<<4 )  /**< Trying to modify a finished BSON object. */
+    BSON_VALID =             0,         /**< BSON is valid and UTF-8 compliant. */
+    BSON_NOT_UTF8 =          (1 << 1),  /**< A key or a string is not valid UTF-8. */
+    BSON_FIELD_HAS_DOT =     (1 << 2),  /**< Warning: key contains '.' character. */
+    BSON_FIELD_INIT_DOLLAR = (1 << 3)   /**< Warning: key starts with '$' character. */
 };
 
 enum bson_binary_subtype_t {

--- a/src/gridfs.c
+++ b/src/gridfs.c
@@ -15,6 +15,10 @@
  *    limitations under the License.
  */
 
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include "gridfs.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/mongo.c
+++ b/src/mongo.c
@@ -15,6 +15,10 @@
  *    limitations under the License.
  */
 
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include "mongo.h"
 #include "md5.h"
 #include "env.h"
@@ -928,7 +932,7 @@ MONGO_EXPORT int mongo_insert_batch( mongo *conn, const char *ns,
             return MONGO_ERROR;
     }
 
-    if( ( size - overhead ) > conn->max_bson_size ) {
+    if( ( size - overhead ) > (size_t)conn->max_bson_size ) {
         conn->err = MONGO_BSON_TOO_LARGE;
         return MONGO_ERROR;
     }


### PR DESCRIPTION
I added error checking to bson_append_finish_object() and modified the bson error codes to support this.  At same time, I eliminated CRT warnings for MSVS
