### PR TITLE
CDRIVER-200 Memory scribble in 'bson_append' when level of nested objects exceeds 32

### DIFF
--- a/src/bson.h
+++ b/src/bson.h
@@ -137,7 +137,8 @@ typedef struct {
     char *cur;     /**< Pointer to the current position. */
     int dataSize;  /**< The number of bytes allocated to char *data. */
     bson_bool_t finished; /**< When finished, the BSON object can no longer be modified. */
-    size_t stack[32];        /**< A stack used to keep track of nested BSON elements. */
+    size_t * stack;       /**< A dynamically resized stack used to keep track of nested BSON elements.*/
+    int stackSize;        /**< Current number of elements in dynamically-resized stack */
     int stackPos;         /**< Index of current stack position. */
     int err; /**< Bitfield representing errors or warnings on this buffer */
     char *errstr; /**< A string representation of the most recent error or warning. */

--- a/src/bson.h
+++ b/src/bson.h
@@ -137,11 +137,12 @@ typedef struct {
     char *cur;     /**< Pointer to the current position. */
     int dataSize;  /**< The number of bytes allocated to char *data. */
     bson_bool_t finished; /**< When finished, the BSON object can no longer be modified. */
-    size_t * stack;       /**< A dynamically resized stack used to keep track of nested BSON elements.*/
-    int stackSize;        /**< Current number of elements in dynamically-resized stack */
+    size_t stack[32];     /**< A stack used to keep track of nested BSON elements.*/
     int stackPos;         /**< Index of current stack position. */
     int err; /**< Bitfield representing errors or warnings on this buffer */
     char *errstr; /**< A string representation of the most recent error or warning. */
+    size_t * stackPtr;    /**< Pointer to the current stack */
+    int stackSize;        /**< Number of elements in the current stack */
 } bson;
 
 #pragma pack(1)

--- a/src/mongo.c
+++ b/src/mongo.c
@@ -416,7 +416,7 @@ MONGO_EXPORT void mongo_init_sockets( void ) {
 /* WC1 is completely static */
 static char WC1_data[] = {23,0,0,0,16,103,101,116,108,97,115,116,101,114,114,111,114,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0};
 static bson WC1_cmd = {
-    WC1_data, WC1_data, 128, 1, {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}, 0, 0, ""
+    WC1_data, WC1_data, 128, 1, 0, 0, 0, 0, ""
 };
 static mongo_write_concern WC1 = { 1, 0, 0, 0, 0, &WC1_cmd }; /* w = 1 */
 

--- a/src/mongo.c
+++ b/src/mongo.c
@@ -416,7 +416,7 @@ MONGO_EXPORT void mongo_init_sockets( void ) {
 /* WC1 is completely static */
 static char WC1_data[] = {23,0,0,0,16,103,101,116,108,97,115,116,101,114,114,111,114,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0};
 static bson WC1_cmd = {
-    WC1_data, WC1_data, 128, 1, 0, 0, 0, 0, ""
+    WC1_data, WC1_data, 128, 1, {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}, 0, 0, "", 0, 0
 };
 static mongo_write_concern WC1 = { 1, 0, 0, 0, 0, &WC1_cmd }; /* w = 1 */
 

--- a/test/bson_test.c
+++ b/test/bson_test.c
@@ -309,11 +309,34 @@ int test_bson_size( void ) {
     return 0;
 }
 
+int test_bson_deep_nesting( void ) {
+    int i;
+    bson b[1];
+    bson_init( b );
+
+    for ( i = 0; i < 128; ++i )
+    {
+        bson_append_start_object( b, "sub" );
+        bson_append_string( b, "hello", "hi" );
+    }
+
+    for ( i = 0; i < 128; ++i )
+    {
+        bson_append_finish_object( b );
+    }
+
+    bson_finish( b );
+    bson_destroy( b );
+
+    return 0;
+}
+
 int main() {
 
   test_bson_generic();
   test_bson_iterator();
   test_bson_size();
+  test_bson_deep_nesting();
 
   return 0;
 }

--- a/test/write_concern_test.c
+++ b/test/write_concern_test.c
@@ -49,7 +49,7 @@ void bson_dump( bson * b ) {
 /* WC1 is completely static */
 static char WC1_data[] = {23,0,0,0,16,103,101,116,108,97,115,116,101,114,114,111,114,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0};
 static bson WC1_cmd = {
-    WC1_data, WC1_data, 128, 1, 0, 0, 0, 0, ""
+    WC1_data, WC1_data, 128, 1, {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}, 0, 0, "", 0, 0
 };
 static mongo_write_concern DWC1 = { 1, 0, 0, 0, 0, 0 }; /* w = 1 */ /* do not reference &WC1_cmd for this test */
 

--- a/test/write_concern_test.c
+++ b/test/write_concern_test.c
@@ -49,7 +49,7 @@ void bson_dump( bson * b ) {
 /* WC1 is completely static */
 static char WC1_data[] = {23,0,0,0,16,103,101,116,108,97,115,116,101,114,114,111,114,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0};
 static bson WC1_cmd = {
-    WC1_data, WC1_data, 128, 1, {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}, 0, 0, ""
+    WC1_data, WC1_data, 128, 1, 0, 0, 0, 0, ""
 };
 static mongo_write_concern DWC1 = { 1, 0, 0, 0, 0, 0 }; /* w = 1 */ /* do not reference &WC1_cmd for this test */
 


### PR DESCRIPTION
A potential fix for CDRIVER-200, in which the the 'bson' structure currently has a hard-coded internal 'stack' of 32 elements. Overflow of this stack is not checked, and happens when you exceed 32 nested objects / arrays with bson_append_start_object / bson_append_start_array.

In this fix, the fixed-size stack has been replaced with a dynamically resized stack. When resized, the stack is incremented by 32, so the additional cost for existing code is 1 malloc when the first object is appended, and 1 free when the structure is free'd. I've also added an additional unit test for deep nesting of bson objects, and verified this patch by running it through all tests with valgrind.

I've pasted the test output below as per the guidelines. If you require any further information, please get in touch.

Thanks.

<pre>
sh runtests.sh
./test_auth
./test_bcon
./test_bson
    d : 1    3.140000
    s : 2    hello
    s_n : 2      goodbye
    o : 3    
        a : 4    
            0 : 5    BSON_BINDATA


    u : 6    BSON_UNDEFINED
    oid : 7      010203040506070809101112
    b : 8    true
    date : 9     72623859790382856
    n : 10   BSON_NULL
    r : 11   BSON_REGEX: ^asdf
    c : 13   BSON_CODE: function(){}
    c_n : 13     BSON_CODE: function(){}
    symbol : 14      SYMBOL: symbol
    symbol_n : 14    SYMBOL: symbol
    cws : 15     BSON_CODE_W_SCOPE: function(){return i}
     SCOPE:     i : 16   123

    timestamp : 17   i: 1, t: 2
    l : 18   1234605616436508552
./test_bson_subobject
./test_connect
WARNING: mongo_connect() is deprecated, please use mongo_client()
./test_count_delete
./test_cursors
./test_endian_swap
./test_errors
./test_examples
    0 : 3    
        name : 2     John Coltrane: Impressions
        price : 16   1099

    1 : 3    
        name : 2     Larry Young: Unity
        price : 16   1199

./test_functions
Test printf 0
Test fprintf 0
Test sprintf 0
Test err 0
./test_gridfs
./test_helpers
    v : 16   1
    key : 3      
        foo : 16     -1

    unique : 8   true
    ns : 2   test.bar
    name : 2     foo_-1
    sparse : 8   true
./test_oid
./test_resize
./test_simple
  _id: (oid) "51309ce3752e8d7d00000000"
  ts: (timestamp) [...]
  a: (double) 1.700000e+01
  b: (int) 17
  c: (string) "17"
  d: (subobject) {...}
  e: (array) [...]

  _id: (oid) "51309ce3752e8d7d00000001"
  ts: (timestamp) [...]
  a: (double) 1.700000e+01
  b: (int) 17
  c: (string) "17"
  d: (subobject) {...}
  e: (array) [...]

  _id: (oid) "51309ce3752e8d7d00000002"
  ts: (timestamp) [...]
  a: (double) 1.700000e+01
  b: (int) 17
  c: (string) "17"
  d: (subobject) {...}
  e: (array) [...]

  _id: (oid) "51309ce3752e8d7d00000003"
  ts: (timestamp) [...]
  a: (double) 1.700000e+01
  b: (int) 17
  c: (string) "17"
  d: (subobject) {...}
  e: (array) [...]

  _id: (oid) "51309ce3752e8d7d00000004"
  ts: (timestamp) [...]
  a: (double) 1.700000e+01
  b: (int) 17
  c: (string) "17"
  d: (subobject) {...}
  e: (array) [...]

./test_sizes
./test_update
./test_validate
./test_write_concern
./test_commands
</pre>
