### PR TITLE
Make consistent use of helper functions to create bson and cursor objects

### DIFF
--- a/src/gridfs.c
+++ b/src/gridfs.c
@@ -60,7 +60,7 @@ static bson *chunk_new( bson_oid_t id, int chunkNumber,
 
 static void chunk_free( bson *oChunk ) {
     bson_destroy( oChunk );
-    bson_free( oChunk );
+    bson_dispose( oChunk );
 }
 
 int gridfs_init( mongo *client, const char *dbname, const char *prefix,

--- a/src/gridfs.c
+++ b/src/gridfs.c
@@ -48,7 +48,7 @@ MONGO_EXPORT void gridfile_get_descriptor(gridfile* gf, bson* out) {
 
 static bson *chunk_new( bson_oid_t id, int chunkNumber,
                         const char *data, size_t len ) {
-    bson *b = bson_malloc( sizeof( bson ) );
+    bson *b = bson_create();
 
     bson_init( b );
     bson_append_oid( b, "files_id", &id );
@@ -461,7 +461,7 @@ int gridfile_init( gridfs *gfs, bson *meta, gridfile *gfile )
 {
     gfile->gfs = gfs;
     gfile->pos = 0;
-    gfile->meta = ( bson * )bson_malloc( sizeof( bson ) );
+    gfile->meta = bson_create();
     if ( gfile->meta == NULL ) return MONGO_ERROR;
     bson_copy( gfile->meta, meta );
     return MONGO_OK;

--- a/src/mongo.c
+++ b/src/mongo.c
@@ -1095,7 +1095,7 @@ MONGO_EXPORT int mongo_write_concern_finish( mongo_write_concern *write_concern 
         command = write_concern->cmd;
     }
     else
-        command = (bson *)bson_malloc( sizeof( bson ) );
+        command = bson_create();
 
     if( !command ) {
         return MONGO_ERROR;
@@ -1286,7 +1286,7 @@ static int mongo_cursor_get_more( mongo_cursor *cursor ) {
 MONGO_EXPORT mongo_cursor *mongo_find( mongo *conn, const char *ns, const bson *query,
                                        const bson *fields, int limit, int skip, int options ) {
 
-    mongo_cursor *cursor = ( mongo_cursor * )bson_malloc( sizeof( mongo_cursor ) );
+    mongo_cursor *cursor = mongo_cursor_create();
     mongo_cursor_init( cursor, conn, ns );
     cursor->flags |= MONGO_CURSOR_MUST_FREE;
 

--- a/src/mongo.c
+++ b/src/mongo.c
@@ -1141,7 +1141,7 @@ MONGO_EXPORT void mongo_write_concern_destroy( mongo_write_concern *write_concer
     if( write_concern->cmd )
         bson_destroy( write_concern->cmd );
 
-    bson_free( write_concern->cmd );
+    bson_dispose( write_concern->cmd );
 }
 
 MONGO_EXPORT void mongo_set_write_concern( mongo *conn,

--- a/test/write_concern_test.c
+++ b/test/write_concern_test.c
@@ -115,10 +115,10 @@ void test_batch_insert_with_continue( mongo *conn ) {
 
     for( i=0; i<5; i++ ) {
         bson_destroy( objs2[i] );
-        bson_free( objs2[i] );
+        bson_dispose( objs2[i] );
 
         bson_destroy( objs[i] );
-        bson_free( objs[i] );
+        bson_dispose( objs[i] );
     }
 }
 
@@ -185,7 +185,7 @@ void test_update_and_remove( mongo *conn ) {
     bson_destroy( update );
     for( i=0; i<5; i++ ) {
         bson_destroy( objs[i] );
-        bson_free( objs[i] );
+        bson_dispose( objs[i] );
     }
 }
 

--- a/test/write_concern_test.c
+++ b/test/write_concern_test.c
@@ -75,7 +75,7 @@ void test_batch_insert_with_continue( mongo *conn ) {
     mongo_create_simple_index( conn, TEST_NS, "n", MONGO_INDEX_UNIQUE, NULL );
 
     for( i=0; i<5; i++ ) {
-        objs[i] = bson_malloc( sizeof( bson ) );
+        objs[i] = bson_create();
         bson_init( objs[i] );
         bson_append_int( objs[i], "n", i );
         bson_finish( objs[i] );
@@ -88,14 +88,14 @@ void test_batch_insert_with_continue( mongo *conn ) {
           bson_empty( &empty ) ) == 5 );
 
     /* Add one duplicate value for n. */
-    objs2[0] = bson_malloc( sizeof( bson ) );
+    objs2[0] = bson_create();
     bson_init( objs2[0] );
     bson_append_int( objs2[0], "n", 1 );
     bson_finish( objs2[0] );
 
     /* Add n for 6 - 9. */
     for( i = 1; i < 5; i++ ) {
-        objs2[i] = bson_malloc( sizeof( bson ) );
+        objs2[i] = bson_create();
         bson_init( objs2[i] );
         bson_append_int( objs2[i], "n", i + 5 );
         bson_finish( objs2[i] );
@@ -134,7 +134,7 @@ void test_update_and_remove( mongo *conn ) {
     create_capped_collection( conn );
 
     for( i=0; i<5; i++ ) {
-        objs[i] = bson_malloc( sizeof( bson ) );
+        objs[i] = bson_create();
         bson_init( objs[i] );
         bson_append_int( objs[i], "n", i );
         bson_finish( objs[i] );


### PR DESCRIPTION
Consistently using the _create() functions helps clarify what they're for and how they should be used.

These changes came from pull request #72.
