### PR TITLE
Call bson_free( ) instead of free( )

### DIFF
--- a/src/gridfs.c
+++ b/src/gridfs.c
@@ -30,7 +30,7 @@ MONGO_EXPORT gridfs* gridfs_create( void ) {
 }
 
 MONGO_EXPORT void gridfs_dispose(gridfs* gfs) {
-    free(gfs);
+    bson_free(gfs);
 }
 
 MONGO_EXPORT gridfile* gridfile_create( void ) {
@@ -38,7 +38,7 @@ MONGO_EXPORT gridfile* gridfile_create( void ) {
 }
 
 MONGO_EXPORT void gridfile_dispose(gridfile* gf) {
-    free(gf);
+    bson_free(gf);
 }
 
 MONGO_EXPORT void gridfile_get_descriptor(gridfile* gf, bson* out) {


### PR DESCRIPTION
This makes these functions consistent with all of the other _dispose functions and the rest of the library.
