### PR TITLE
Update SConstruct

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -88,7 +88,7 @@ env.AlwaysBuild("docs")
 PLATFORM_TESTS = []
 NET_LIB = "src/env.c"
 if GetOption('standard_env'):
-    env.Append( CPPFLAGS=" -D_POSIX_SOURCE" )
+    env.Append( CPPFLAGS=" -DMONGO_ENV_STANDARD " )
 elif os.sys.platform in ["darwin", "linux2"]:
     PLATFORM_TESTS = [ "env_posix", "unix_socket" ]
 elif 'win32' == os.sys.platform:


### PR DESCRIPTION
Changing " -D_POSIX_SOURCE" for " -DMONGO_ENV_STANDARD " to build with MinGW on 32-bit Windows OS
Compiling with scons --m32 --standard-env
