### PR TITLE
Replace bson_empty with bson_init_empty and bson_shared_empty

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -33,8 +33,8 @@ const int initialBufferSize = 128;
 /* only need one of these */
 static const int zero = 0;
 
-/* Static data to use with bson_empty( ) */
-static char *bson_shared_empty_data = "\005\0\0\0\0";
+/* Static data to use with bson_init_empty( ) and bson_shared_empty( ) */
+static char bson_shared_empty_data[] = {5,0,0,0,0};
 
 /* Custom standard function pointers. */
 void *( *bson_malloc_func )( size_t ) = malloc;
@@ -94,9 +94,14 @@ int bson_init_finished_data_with_copy( bson *b, const char *data ) {
     return BSON_OK;
 }
 
-MONGO_EXPORT const bson *bson_empty( bson *obj ) {
+MONGO_EXPORT bson_bool_t bson_init_empty( bson *obj ) {
     bson_init_finished_data( obj, bson_shared_empty_data, 0 );
-    return obj;
+    return BSON_OK;
+}
+
+MONGO_EXPORT const bson *bson_shared_empty( ) {
+    static const bson shared_empty = { bson_shared_empty_data, bson_shared_empty_data, 128, 1, 0, {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}, 0, 0, 0, 0 };
+    return &shared_empty;
 }
 
 MONGO_EXPORT int bson_copy( bson *out, const bson *in ) {
@@ -540,7 +545,7 @@ MONGO_EXPORT void bson_iterator_code_scope_init( const bson_iterator *i, bson *s
             bson_init_finished_data( scope, (char *)scopeData, 0 );
     }
     else {
-        bson_empty( scope );
+        bson_init_empty( scope );
     }
 }
 

--- a/src/bson.h
+++ b/src/bson.h
@@ -168,8 +168,8 @@ typedef struct {
  * Allocate memory for a new BSON object.
  *
  * @note After using this function, you must initialize the object
- * using bson_init_finished_data( ), bson_init( ), or one of the other
- * init functions.
+ * using bson_init_finished_data( ), bson_init_empty( ), bson_init( ),
+ * or one of the other init functions.
  *
  * @return a new BSON object.
  */
@@ -469,7 +469,7 @@ MONGO_EXPORT const char *bson_iterator_code( const bson_iterator *i );
 
 /**
  * Get the code scope value of the BSON object currently pointed to
- * by the iterator. Calls bson_empty on scope if current object is
+ * by the iterator. Calls bson_init_empty on scope if current object is
  * not BSON_CODEWSCOPE.
  *
  * @note When copyData is false, the scope becomes invalid when the
@@ -707,14 +707,26 @@ MONGO_EXPORT void bson_destroy( bson *b );
 
 /**
  * Initialize a BSON object to an emoty object with a shared, static data
- * buffer, and returns it. It is safe to call bson_destroy( ) on this
- * object.
+ * buffer, and returns it.
+ *
+ * @note You must NOT modify this object's data. It is safe though not
+ * required to call bson_destroy( ) on this object.
  *
  * @param obj the BSON object to initialize.
  *
- * @return the empty initialized BSON object.
+ * @return BSON_OK
  */
-MONGO_EXPORT const bson *bson_empty( bson *obj );
+MONGO_EXPORT bson_bool_t bson_init_empty( bson *obj );
+
+/**
+ * Return a pointer to an empty, shared, static BSON object.
+ *
+ * @note This object is owned by the driver. You must NOT modify it
+ * and must NOT call bson_destroy( ) on it.
+ *
+ * @return the shared initialized BSON object.
+ */
+MONGO_EXPORT const bson *bson_shared_empty( );
 
 /**
  * Make a complete copy of the a BSON object.

--- a/src/bson.h
+++ b/src/bson.h
@@ -198,7 +198,7 @@ MONGO_EXPORT void bson_dispose( bson* b );
 int bson_init_finished_data( bson *b, char *data, bson_bool_t ownsData );
 
 /**
- * Initialize a BSON object for reading and copies finalized
+ * Initialize a BSON object for reading and copy finalized
  * BSON data from the provided char*.
  *
  * @note When done using the bson object, you must pass
@@ -707,7 +707,7 @@ MONGO_EXPORT void bson_destroy( bson *b );
 
 /**
  * Initialize a BSON object to an emoty object with a shared, static data
- * buffer, and returns it.
+ * buffer.
  *
  * @note You must NOT modify this object's data. It is safe though not
  * required to call bson_destroy( ) on this object.

--- a/src/gridfs.c
+++ b/src/gridfs.c
@@ -545,7 +545,7 @@ MONGO_EXPORT void gridfile_get_metadata( gridfile *gfile, bson* out, bson_bool_t
     if ( bson_find( &it, gfile->meta, "metadata" ) )
         bson_iterator_subobject_init( &it, out, copyData );
     else
-        bson_empty( out );
+        bson_init_empty( out );
 }
 
 MONGO_EXPORT int gridfile_get_numchunks( gridfile *gfile ) {
@@ -588,9 +588,7 @@ MONGO_EXPORT void gridfile_get_chunk( gridfile *gfile, int n, bson* out ) {
                              &query, NULL, out ) == MONGO_OK );
     bson_destroy( &query );
     if (!result) {
-        bson empty;
-        bson_empty(&empty);
-        bson_copy(out, &empty);
+        bson_init_empty( out );
     }
 }
 

--- a/src/gridfs.h
+++ b/src/gridfs.h
@@ -260,7 +260,7 @@ bson_bool_t gridfile_get_boolean( gridfile *gfile,
                                   const char *name );
 
 /**
- *  Returns the metadata of GridFile. Calls bson_empty on metadata
+ *  Returns the metadata of GridFile. Calls bson_init_empty on metadata
  *  if none exits.
  *
  * @note When copyData is false, the metadata object becomes invalid

--- a/src/mongo.c
+++ b/src/mongo.c
@@ -823,12 +823,11 @@ static int mongo_check_last_error( mongo *conn, const char *ns,
                                    mongo_write_concern *write_concern ) {
     int ret = MONGO_OK;
     bson response = {NULL, 0};
-    bson fields;
     bson_iterator it;
     int res = 0;
     char *cmd_ns = mongo_ns_to_cmd_db( ns );
 
-    res = mongo_find_one( conn, cmd_ns, write_concern->cmd, bson_empty( &fields ), &response );
+    res = mongo_find_one( conn, cmd_ns, write_concern->cmd, bson_shared_empty( ), &response );
     bson_free( cmd_ns );
 
     if( res != MONGO_OK )
@@ -1167,7 +1166,6 @@ MONGO_EXPORT void mongo_write_concern_destroy( mongo_write_concern *write_concer
 
 static int mongo_cursor_op_query( mongo_cursor *cursor ) {
     int res;
-    bson empty;
     char *data;
     mongo_message *mm;
     bson temp;
@@ -1178,12 +1176,12 @@ static int mongo_cursor_op_query( mongo_cursor *cursor ) {
 
     /* Set up default values for query and fields, if necessary. */
     if( ! cursor->query )
-        cursor->query = bson_empty( &empty );
+        cursor->query = bson_shared_empty( );
     else if( mongo_cursor_bson_valid( cursor, cursor->query ) != MONGO_OK )
         return MONGO_ERROR;
 
     if( ! cursor->fields )
-        cursor->fields = bson_empty( &empty );
+        cursor->fields = bson_shared_empty( );
     else if( mongo_cursor_bson_valid( cursor, cursor->fields ) != MONGO_OK )
         return MONGO_ERROR;
 
@@ -1578,7 +1576,6 @@ MONGO_EXPORT int mongo_run_command( mongo *conn, const char *db, const bson *com
                                     bson *out ) {
     int ret = MONGO_OK;
     bson response = {NULL, 0};
-    bson fields;
     size_t sl = strlen( db );
     char *ns = bson_malloc( sl + 5 + 1 ); /* ".$cmd" + nul */
     int res, success = 0;
@@ -1586,7 +1583,7 @@ MONGO_EXPORT int mongo_run_command( mongo *conn, const char *db, const bson *com
     strcpy( ns, db );
     strcpy( ns+sl, ".$cmd" );
 
-    res = mongo_find_one( conn, ns, command, bson_empty( &fields ), &response );
+    res = mongo_find_one( conn, ns, command, bson_shared_empty( ), &response );
     bson_free( ns );
 
     if( res != MONGO_OK )

--- a/test/bson_test.c
+++ b/test/bson_test.c
@@ -283,14 +283,13 @@ int test_bson_generic( void ) {
 }
 
 int test_bson_iterator( void ) {
-    bson b[1];
     bson_iterator i[1];
 
-    bson_iterator_init( i, bson_empty( b ) );
+    bson_iterator_init( i, bson_shared_empty( ) );
     bson_iterator_next( i );
     bson_iterator_type( i );
 
-    bson_find( i, bson_empty( b ), "foo" );
+    bson_find( i, bson_shared_empty( ), "foo" );
 
     return 0;
 }

--- a/test/cursors_test.c
+++ b/test/cursors_test.c
@@ -42,14 +42,13 @@ void remove_sample_data( mongo *conn ) {
 
 int test_multiple_getmore( mongo *conn ) {
     mongo_cursor *cursor;
-    bson b;
     int count;
 
     remove_sample_data( conn );
     create_capped_collection( conn );
     insert_sample_data( conn, 10000 );
 
-    cursor = mongo_find( conn, "test.cursors", bson_empty( &b ), bson_empty( &b ), 0, 0, 0 );
+    cursor = mongo_find( conn, "test.cursors", bson_shared_empty( ), bson_shared_empty( ), 0, 0, 0 );
 
     count = 0;
     while( mongo_cursor_next( cursor ) == MONGO_OK )
@@ -67,7 +66,7 @@ int test_multiple_getmore( mongo *conn ) {
 
 int test_tailable( mongo *conn ) {
     mongo_cursor *cursor;
-    bson b, e;
+    bson b;
     int count;
 
     remove_sample_data( conn );
@@ -82,7 +81,7 @@ int test_tailable( mongo *conn ) {
     bson_append_finish_object( &b );
     bson_finish( &b );
 
-    cursor = mongo_find( conn, "test.cursors", &b, bson_empty( &e ), 0, 0, MONGO_TAILABLE );
+    cursor = mongo_find( conn, "test.cursors", &b, bson_shared_empty( ), 0, 0, MONGO_TAILABLE );
     bson_destroy( &b );
 
     count = 0;

--- a/test/env_posix_test.c
+++ b/test/env_posix_test.c
@@ -14,7 +14,7 @@
  */
 int test_read_timeout( void ) {
     mongo conn[1];
-    bson b, obj, out, fields;
+    bson b, obj, out;
     int res;
 
     if ( mongo_client( conn, TEST_SERVER, 27017 ) ) {
@@ -36,7 +36,7 @@ int test_read_timeout( void ) {
     mongo_set_op_timeout( conn, 1000 );
     ASSERT( res == MONGO_OK );
 
-    res = mongo_find_one( conn, "test.foo", &b, bson_empty(&fields), &out );
+    res = mongo_find_one( conn, "test.foo", &b, bson_shared_empty( ), &out );
     ASSERT( res == MONGO_ERROR );
 
     ASSERT( conn->err == MONGO_IO_ERROR );

--- a/test/errors_test.c
+++ b/test/errors_test.c
@@ -235,7 +235,7 @@ int test_get_last_error_commands( void ) {
     bson_destroy( &obj );
 
     /* should clear lasterror but not preverror */
-    mongo_find_one( conn, ns, bson_empty( &obj ), bson_empty( &obj ), NULL );
+    mongo_find_one( conn, ns, bson_shared_empty( ), bson_shared_empty( ), NULL );
 
     ASSERT( mongo_cmd_get_prev_error( conn, db, NULL ) == MONGO_ERROR );
     ASSERT( mongo_cmd_get_last_error( conn, db, NULL ) == MONGO_OK );

--- a/test/replset_test.c
+++ b/test/replset_test.c
@@ -76,7 +76,6 @@ int test_reconnect( const char *set_name ) {
     mongo conn[1];
     int res = 0;
     int e = 0;
-    bson b;
 
     INIT_SOCKETS_FOR_WINDOWS;
 
@@ -93,7 +92,7 @@ int test_reconnect( const char *set_name ) {
         sleep( 10 );
         e = 1;
         do {
-            res = mongo_find_one( conn, "foo.bar", bson_empty( &b ), bson_empty( &b ), NULL );
+            res = mongo_find_one( conn, "foo.bar", bson_empty( ), bson_empty( ), NULL );
             if( res == MONGO_ERROR && conn->err == MONGO_IO_ERROR ) {
                 sleep( 2 );
                 if( e++ < 30 ) {

--- a/test/simple_test.c
+++ b/test/simple_test.c
@@ -69,7 +69,7 @@ int main() {
     }
 
     mongo_cmd_drop_collection( conn, "test", col, NULL );
-    mongo_find_one( conn, ns, bson_empty( &b ), bson_empty( &b ), NULL );
+    mongo_find_one( conn, ns, bson_shared_empty( ), bson_shared_empty( ), NULL );
 
     for( i=0; i< 5; i++ ) {
         bson_init( &b );

--- a/test/update_test.c
+++ b/test/update_test.c
@@ -22,7 +22,7 @@ int main() {
 
     /* if the collection doesn't exist dropping it will fail */
     if ( mongo_cmd_drop_collection( conn, "test", col, NULL ) == MONGO_OK
-            && mongo_find_one( conn, ns, bson_empty( &obj ), bson_empty( &obj ), NULL ) != MONGO_OK ) {
+            && mongo_find_one( conn, ns, bson_shared_empty( ), bson_shared_empty( ), NULL ) != MONGO_OK ) {
         printf( "failed to drop collection\n" );
         exit( 1 );
     }

--- a/test/validate_test.c
+++ b/test/validate_test.c
@@ -18,7 +18,7 @@ static void make_small_invalid( bson *out, int i ) {
 
 int main() {
     mongo conn[1];
-    bson b, empty;
+    bson b;
     mongo_cursor cursor[1];
     unsigned char not_utf8[3];
     int result = 0;
@@ -87,7 +87,7 @@ int main() {
     ASSERT( result == MONGO_ERROR );
     ASSERT( conn->err & MONGO_BSON_NOT_FINISHED );
 
-    result = mongo_update( conn, ns, bson_empty( &empty ), &b, 0, NULL );
+    result = mongo_update( conn, ns, bson_shared_empty( ), &b, 0, NULL );
     ASSERT( result == MONGO_ERROR );
     ASSERT( conn->err & MONGO_BSON_NOT_FINISHED );
 

--- a/test/write_concern_test.c
+++ b/test/write_concern_test.c
@@ -67,7 +67,6 @@ void test_write_concern_finish( void ) {
 void test_batch_insert_with_continue( mongo *conn ) {
     bson *objs[5];
     bson *objs2[5];
-    bson empty;
     int i;
 
     mongo_cmd_drop_collection( conn, TEST_DB, TEST_COL, NULL );
@@ -84,7 +83,7 @@ void test_batch_insert_with_continue( mongo *conn ) {
         NULL, 0 ) == MONGO_OK );
 
     ASSERT( mongo_count( conn, TEST_DB, TEST_COL,
-          bson_empty( &empty ) ) == 5 );
+          bson_shared_empty( ) ) == 5 );
 
     /* Add one duplicate value for n. */
     objs2[0] = bson_create();
@@ -104,13 +103,13 @@ void test_batch_insert_with_continue( mongo *conn ) {
     ASSERT( mongo_insert_batch( conn, TEST_NS, (const bson **)objs2, 5,
         NULL, 0 ) == MONGO_OK );
     ASSERT( mongo_count( conn, TEST_DB, TEST_COL,
-          bson_empty( &empty ) ) == 5 );
+          bson_shared_empty( ) ) == 5 );
 
     /* With continue on error, will insert four documents. */
     ASSERT( mongo_insert_batch( conn, TEST_NS, (const bson **)objs2, 5,
         NULL, MONGO_CONTINUE_ON_ERROR ) == MONGO_OK );
     ASSERT( mongo_count( conn, TEST_DB, TEST_COL,
-          bson_empty( &empty ) ) == 9 );
+          bson_shared_empty( ) ) == 9 );
 
     for( i=0; i<5; i++ ) {
         bson_destroy( objs2[i] );
@@ -127,7 +126,6 @@ void test_update_and_remove( mongo *conn ) {
     mongo_write_concern wc[1];
     bson *objs[5];
     bson query[1], update[1];
-    bson empty;
     int i;
 
     create_capped_collection( conn );
@@ -142,13 +140,13 @@ void test_update_and_remove( mongo *conn ) {
     ASSERT( mongo_insert_batch( conn, "test.wc", (const bson **)objs, 5,
         NULL, 0 ) == MONGO_OK );
 
-    ASSERT( mongo_count( conn, "test", "wc", bson_empty( &empty ) ) == 5 );
+    ASSERT( mongo_count( conn, "test", "wc", bson_shared_empty( ) ) == 5 );
 
     bson_init( query );
     bson_append_int( query, "n", 2 );
     bson_finish( query );
 
-    ASSERT( mongo_find_one( conn, "test.wc", query, bson_empty( &empty ), NULL ) == MONGO_OK );
+    ASSERT( mongo_find_one( conn, "test.wc", query, bson_shared_empty( ), NULL ) == MONGO_OK );
 
     bson_init( update );
         bson_append_start_object( update, "$set" );
@@ -157,13 +155,13 @@ void test_update_and_remove( mongo *conn ) {
     bson_finish( update );
 
     /* Update will appear to succeed with no write concern specified, but doesn't. */
-    ASSERT( mongo_find_one( conn, "test.wc", query, bson_empty( &empty ), NULL ) == MONGO_OK );
+    ASSERT( mongo_find_one( conn, "test.wc", query, bson_shared_empty( ), NULL ) == MONGO_OK );
     ASSERT( mongo_update( conn, "test.wc", query, update, 0, NULL ) == MONGO_OK );
-    ASSERT( mongo_find_one( conn, "test.wc", query, bson_empty( &empty ), NULL ) == MONGO_OK );
+    ASSERT( mongo_find_one( conn, "test.wc", query, bson_shared_empty( ), NULL ) == MONGO_OK );
 
     /* Remove will appear to succeed with no write concern specified, but doesn't. */
     ASSERT( mongo_remove( conn, "test.wc", query, NULL ) == MONGO_OK );
-    ASSERT( mongo_find_one( conn, "test.wc", query, bson_empty( &empty ), NULL ) == MONGO_OK );
+    ASSERT( mongo_find_one( conn, "test.wc", query, bson_shared_empty( ), NULL ) == MONGO_OK );
 
     mongo_write_concern_init( wc );
     wc->w = 1;
@@ -235,7 +233,7 @@ void test_write_concern_input( mongo *conn ) {
 
 void test_insert( mongo *conn ) {
     mongo_write_concern wc0[1], wc1[1];
-    bson b[1], b2[1], b3[1], b4[1], empty[1];
+    bson b[1], b2[1], b3[1], b4[1];
     bson *objs[2];
 
     mongo_cmd_drop_collection( conn, TEST_DB, TEST_COL, NULL );
@@ -253,7 +251,7 @@ void test_insert( mongo *conn ) {
 
     ASSERT( mongo_insert( conn, TEST_NS, b4, wc1 ) == MONGO_OK );
 
-    ASSERT( mongo_remove( conn, TEST_NS, bson_empty( empty ), wc1 ) == MONGO_OK );
+    ASSERT( mongo_remove( conn, TEST_NS, bson_shared_empty( ), wc1 ) == MONGO_OK );
 
     bson_init( b );
     bson_append_new_oid( b, "_id" );
@@ -296,9 +294,9 @@ void test_insert( mongo *conn ) {
 
     /* Insert two new documents by insert_batch. */
     conn->write_concern = NULL;
-    ASSERT( mongo_count( conn, TEST_DB, TEST_COL, bson_empty( empty ) ) == 1 );
+    ASSERT( mongo_count( conn, TEST_DB, TEST_COL, bson_shared_empty( ) ) == 1 );
     ASSERT( mongo_insert_batch( conn, TEST_NS, (const bson **)objs, 2, NULL, 0 ) == MONGO_OK );
-    ASSERT( mongo_count( conn, TEST_DB, TEST_COL, bson_empty( empty ) ) == 3 );
+    ASSERT( mongo_count( conn, TEST_DB, TEST_COL, bson_shared_empty( ) ) == 3 );
 
     /* This should definitely fail if we try again with write concern. */
     mongo_clear_errors( conn );


### PR DESCRIPTION
These are a couple tweaks to the conventions adopted in pull request #93.

`bson_init_empty` gets a name and behavior like every other initializer. This also clarifies that empty objects don't need to be passed to `bson_destroy( )`.

When the programmer needs an empty BSON object, s/he can now get one with `bson_shared_empty()` without needing to allocate one first.

The changes to mongo.c and the tests illustrate the way this simplifies things.
