### PR TITLE
Update SConstruct

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -115,6 +115,11 @@ if os.sys.platform in ["darwin", "linux2"]:
 elif 'win32' == os.sys.platform:
     env.Append( CPPFLAGS="-DMONGO_HAVE_STDINT" )
     env.Append( LIBS='ws2_32' )
+    if env['CC'] == 'gcc':
+        if not GetOption('standard_env'):
+            env.Append( CPPFLAGS=" -D_WIN32_WINNT=0x0501 " )
+        if GetOption('optimize'):
+            env.Append( CPPFLAGS=" -O3 " )
 
 #we shouldn't need these options in c99 mode
 if not GetOption('use_c99'):


### PR DESCRIPTION
Add " -D_WIN32_WINNT=0x0501 " to link with getaddrinfo and
Add optimizations when build with MinGW on 32-bit Windows OS.

<<Since the getaddrinfo() is available to Windows XP onwards,
it is sufficient to use that windows version code as the value
of the constant mentioned above.>>

Compiling with scons --m32
