### PR TITLE
Added code to initialize bson to zero when dynamically allocating and fixed memleak on mongo.c

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -63,7 +63,9 @@ static int ( *oid_inc_func )( void )  = NULL;
    ------------------------------ */
 
 MONGO_EXPORT bson* bson_create( void ) {
-    return (bson*)bson_malloc(sizeof(bson));
+    bson* b = (bson*)bson_malloc(sizeof(bson));
+    _bson_zero( b ); 
+    return b;
 }
 
 MONGO_EXPORT void bson_dispose(bson* b) {

--- a/src/bson.c
+++ b/src/bson.c
@@ -64,7 +64,8 @@ static int ( *oid_inc_func )( void )  = NULL;
 
 MONGO_EXPORT bson* bson_create( void ) {
     bson* b = (bson*)bson_malloc(sizeof(bson));
-    _bson_zero( b ); 
+    b->ownsData = 0;
+    b->stackPtr = NULL;
     return b;
 }
 

--- a/src/mongo.c
+++ b/src/mongo.c
@@ -671,7 +671,7 @@ MONGO_EXPORT int mongo_replica_set_client( mongo *conn ) {
 
                 /* Primary found, so return. */
                 else if( conn->replica_set->primary_connected ) {
-                    if( conn->primary = NULL ) {
+                    if( conn->primary == NULL ) {
                       conn->primary = (mongo_host_port*)bson_malloc( sizeof( mongo_host_port ) );
                     }                    
                     strncpy( conn->primary->host, node->host, strlen( node->host ) + 1 );

--- a/src/mongo.c
+++ b/src/mongo.c
@@ -671,12 +671,9 @@ MONGO_EXPORT int mongo_replica_set_client( mongo *conn ) {
 
                 /* Primary found, so return. */
                 else if( conn->replica_set->primary_connected ) {
-                    if( conn->primary ) {
-                      /* If we don't free primary we will have a memory leak */
-                      bson_free( conn->primary );
-                      conn->primary = NULL;
-                    }
-                    conn->primary = bson_malloc( sizeof( mongo_host_port ) );
+                    if( conn->primary = NULL ) {
+                      conn->primary = (mongo_host_port*)bson_malloc( sizeof( mongo_host_port ) );
+                    }                    
                     strncpy( conn->primary->host, node->host, strlen( node->host ) + 1 );
                     conn->primary->port = node->port;
                     return MONGO_OK;

--- a/src/mongo.c
+++ b/src/mongo.c
@@ -671,6 +671,11 @@ MONGO_EXPORT int mongo_replica_set_client( mongo *conn ) {
 
                 /* Primary found, so return. */
                 else if( conn->replica_set->primary_connected ) {
+                    if( conn->primary ) {
+                      /* If we don't free primary we will have a memory leak */
+                      bson_free( conn->primary );
+                      conn->primary = NULL;
+                    }
                     conn->primary = bson_malloc( sizeof( mongo_host_port ) );
                     strncpy( conn->primary->host, node->host, strlen( node->host ) + 1 );
                     conn->primary->port = node->port;


### PR DESCRIPTION
Added code on bson.c to initialize to zero newly allocated bson. The problem with not doing this, is that in many places a bson object is created in order to pass as reference to a function which will "fill it". but if anything fails and the data field, or owned field are not properly initialize further calls to bson_destroy fail badly.

Change to mongo.c fixed a memory leak initializing replicate set. When doing this, primary must be freed first before assigning a new pointer with malloc
