### PR TITLE
Clear a "no previous prototype for function" warning with the Apple LLVM compiler

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -99,7 +99,7 @@ MONGO_EXPORT bson_bool_t bson_init_empty( bson *obj ) {
     return BSON_OK;
 }
 
-MONGO_EXPORT const bson *bson_shared_empty( ) {
+MONGO_EXPORT const bson *bson_shared_empty( void ) {
     static const bson shared_empty = { bson_shared_empty_data, bson_shared_empty_data, 128, 1, 0, {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}, 0, 0, 0, 0 };
     return &shared_empty;
 }

--- a/src/bson.h
+++ b/src/bson.h
@@ -726,7 +726,7 @@ MONGO_EXPORT bson_bool_t bson_init_empty( bson *obj );
  *
  * @return the shared initialized BSON object.
  */
-MONGO_EXPORT const bson *bson_shared_empty( );
+MONGO_EXPORT const bson *bson_shared_empty( void );
 
 /**
  * Make a complete copy of the a BSON object.


### PR DESCRIPTION
gcc didn't complain about this, but Apple LLVM can't find the declaration and throws a warning.
