### PR TITLE
Clear compiler warning on gcc

### DIFF
--- a/src/gridfs.c
+++ b/src/gridfs.c
@@ -30,15 +30,19 @@
 char *_strupr(char *str)
 {
    char *s = str;
-   while (*s)
-        *s++ = toupper((unsigned char)*s);
+   while (*s) {
+        *s = toupper((unsigned char)*s);
+        ++s;
+      }
    return str;
 }
 char *_strlwr(char *str)
 {
    char *s = str;
-   while (*s)
-        *s++ = tolower((unsigned char)*s);
+   while (*s) {
+        *s = tolower((unsigned char)*s);
+        ++s;
+   }
    return str;
 }
 #endif


### PR DESCRIPTION
For some reason `*s++ =` yields this:
`warning: operation on ‘s’ may be undefined`
