### PR TITLE
Rename create and dispose to alloc and dealloc

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -62,12 +62,12 @@ static int ( *oid_inc_func )( void )  = NULL;
    READING
    ------------------------------ */
 
-MONGO_EXPORT bson* bson_create( void ) {
-    return (bson*)bson_malloc(sizeof(bson));
+MONGO_EXPORT bson* bson_alloc( void ) {
+    return ( bson* )bson_malloc( sizeof( bson ) );
 }
 
-MONGO_EXPORT void bson_dispose(bson* b) {
-    bson_free(b);
+MONGO_EXPORT void bson_dealloc( bson* b ) {
+    bson_free( b );
 }
 
 /* When passed a char * of a BSON data block, returns its reported size */
@@ -289,12 +289,12 @@ MONGO_EXPORT void bson_print_raw( const char *data , int depth ) {
    ITERATOR
    ------------------------------ */
 
-MONGO_EXPORT bson_iterator* bson_iterator_create( void ) {
-    return ( bson_iterator* )malloc( sizeof( bson_iterator ) );
+MONGO_EXPORT bson_iterator* bson_iterator_alloc( void ) {
+    return ( bson_iterator* )bson_malloc( sizeof( bson_iterator ) );
 }
 
-MONGO_EXPORT void bson_iterator_dispose(bson_iterator* i) {
-    free(i);
+MONGO_EXPORT void bson_iterator_dealloc( bson_iterator* i ) {
+    bson_free( i );
 }
 
 MONGO_EXPORT void bson_iterator_init( bson_iterator *i, const bson *b ) {

--- a/src/bson.h
+++ b/src/bson.h
@@ -177,14 +177,14 @@ typedef struct {
  *
  * @return a new BSON object.
  */
-MONGO_EXPORT bson* bson_create( void );
+MONGO_EXPORT bson* bson_alloc( void );
 
 /**
  * Deallocate a BSON object.
  *
  * @note You must call bson_destroy( ) before calling this function.
  */
-MONGO_EXPORT void bson_dispose( bson* b );
+MONGO_EXPORT void bson_dealloc( bson* b );
 
 /**
  * Initialize a BSON object for reading and set its data
@@ -267,7 +267,7 @@ MONGO_EXPORT void bson_print_raw( const char *bson , int depth );
 MONGO_EXPORT bson_type bson_find( bson_iterator *it, const bson *obj, const char *name );
 
 
-MONGO_EXPORT bson_iterator* bson_iterator_create( void );
+MONGO_EXPORT bson_iterator* bson_iterator_alloc( void );
 MONGO_EXPORT void bson_iterator_dispose(bson_iterator*);
 /**
  * Initialize a bson_iterator.

--- a/src/gridfs.c
+++ b/src/gridfs.c
@@ -44,13 +44,12 @@ char *_strlwr(char *str)
 #endif
 
 /* Memory allocation functions */
-MONGO_EXPORT gridfs *gridfs_create( void ) {
-  gridfs* GridFs = (gridfs*)bson_malloc(sizeof(gridfs));
-  return GridFs;
+MONGO_EXPORT gridfs *gridfs_alloc( void ) {
+  return ( gridfs* )bson_malloc( sizeof( gridfs ) );
 }
 
-MONGO_EXPORT void gridfs_dispose(gridfs *gfs) {  
-  bson_free(gfs);
+MONGO_EXPORT void gridfs_dealloc( gridfs *gfs ) {
+  bson_free( gfs );
 }
 
 MONGO_EXPORT gridfile *gridfile_create( void ) {
@@ -59,8 +58,8 @@ MONGO_EXPORT gridfile *gridfile_create( void ) {
   return gfile;
 }
 
-MONGO_EXPORT void gridfile_dispose(gridfile *gf) {
-  bson_free(gf);
+MONGO_EXPORT void gridfile_dealloc( gridfile *gf ) {
+  bson_free( gf );
 }
 
 MONGO_EXPORT void gridfile_get_descriptor(gridfile *gf, bson *out) {
@@ -90,7 +89,7 @@ static gridfs_postProcessingFunc postProcessChunk = defaultPostProcessChunk;
 static gridfs_pendingDataNeededSizeFunc pendingDataNeededSize = defaultDendingDataNeededSize;
 
 static bson *chunk_new(bson_oid_t id, int chunkNumber, void** dataBuf, void* srcData, size_t len, int flags ) {
-  bson *b = (bson*)bson_malloc(sizeof(bson));
+  bson *b = bson_alloc();
   size_t dataBufLen = 0;
 
   if( preProcessChunk( dataBuf, &dataBufLen, srcData, len, flags) != 0 ) {
@@ -107,7 +106,7 @@ static bson *chunk_new(bson_oid_t id, int chunkNumber, void** dataBuf, void* src
 static void chunk_free(bson *oChunk) {
   if( oChunk ) {
     bson_destroy(oChunk);
-    bson_free(oChunk);
+    bson_dealloc(oChunk);
   }
 }
 /* End of memory allocation functions */
@@ -500,7 +499,7 @@ MONGO_EXPORT int gridfile_init(gridfs *gfs, bson *meta, gridfile *gfile){
   gfile->pos = 0;
   gfile->pending_len = 0;
   gfile->pending_data = NULL;
-  gfile->meta = (bson*)bson_malloc(sizeof(bson));
+  gfile->meta = bson_alloc();
   if (gfile->meta == NULL) {
     return MONGO_ERROR;
   } if( meta ) { 
@@ -633,7 +632,7 @@ MONGO_EXPORT void gridfile_destroy(gridfile *gfile)
 {
   if( gfile->meta ) { 
     bson_destroy(gfile->meta);
-    bson_free(gfile->meta);
+    bson_dealloc(gfile->meta);
     gfile->meta = NULL;
   }  
 }

--- a/src/gridfs.h
+++ b/src/gridfs.h
@@ -70,10 +70,10 @@ typedef int ( *gridfs_preProcessingFunc )( void** targetBuf, size_t* targetLen, 
 typedef int ( *gridfs_postProcessingFunc )( void** targetBuf, size_t* targetLen, void* srcData, size_t srcLen, int flags );
 typedef size_t ( *gridfs_pendingDataNeededSizeFunc ) (int flags);
 
-MONGO_EXPORT gridfs* gridfs_create( void );
-MONGO_EXPORT void gridfs_dispose(gridfs* gfs);
+MONGO_EXPORT gridfs* gridfs_alloc( void );
+MONGO_EXPORT void gridfs_dealloc(gridfs* gfs);
 MONGO_EXPORT gridfile* gridfile_create( void );
-MONGO_EXPORT void gridfile_dispose(gridfile* gf);
+MONGO_EXPORT void gridfile_dealloc(gridfile* gf);
 MONGO_EXPORT void gridfile_get_descriptor(gridfile* gf, bson* out);
 MONGO_EXPORT void setBufferProcessingProcs(gridfs_preProcessingFunc preProcessFunc, gridfs_postProcessingFunc postProcessFunc, gridfs_pendingDataNeededSizeFunc pendingDataNeededSizeFunc);
 

--- a/src/mongo.c
+++ b/src/mongo.c
@@ -26,13 +26,13 @@
 #include <string.h>
 #include <assert.h>
 
-MONGO_EXPORT mongo* mongo_create( void ) {
-    return (mongo*)bson_malloc(sizeof(mongo));
+MONGO_EXPORT mongo* mongo_alloc( void ) {
+    return ( mongo* )bson_malloc( sizeof( mongo ) );
 }
 
 
-MONGO_EXPORT void mongo_dispose(mongo* conn) {
-    bson_free(conn);
+MONGO_EXPORT void mongo_dealloc(mongo* conn) {
+    bson_free( conn );
 }
 
 MONGO_EXPORT int mongo_get_err(mongo* conn) {
@@ -95,23 +95,23 @@ MONGO_EXPORT const char* mongo_get_host(mongo* conn, int i) {
     return 0;
 }
 
-MONGO_EXPORT mongo_write_concern* mongo_write_concern_create( void ) {
-    return (mongo_write_concern*)bson_malloc(sizeof(mongo_write_concern));
+MONGO_EXPORT mongo_write_concern* mongo_write_concern_alloc( void ) {
+    return ( mongo_write_concern* )bson_malloc( sizeof( mongo_write_concern ) );
 }
 
 
-MONGO_EXPORT void mongo_write_concern_dispose(mongo_write_concern* write_concern) {
-    bson_free(write_concern);
+MONGO_EXPORT void mongo_write_concern_dealloc( mongo_write_concern* write_concern ) {
+    bson_free( write_concern );
 }
 
 
-MONGO_EXPORT mongo_cursor* mongo_cursor_create( void ) {
-    return (mongo_cursor*)bson_malloc(sizeof(mongo_cursor));
+MONGO_EXPORT mongo_cursor* mongo_cursor_alloc( void ) {
+    return ( mongo_cursor* )bson_malloc( sizeof( mongo_cursor ) );
 }
 
 
-MONGO_EXPORT void mongo_cursor_dispose(mongo_cursor* cursor) {
-    bson_free(cursor);
+MONGO_EXPORT void mongo_cursor_dealloc( mongo_cursor* cursor ) {
+    bson_free( cursor );
 }
 
 
@@ -1094,7 +1094,7 @@ MONGO_EXPORT int mongo_write_concern_finish( mongo_write_concern *write_concern 
         command = write_concern->cmd;
     }
     else
-        command = bson_create();
+        command = bson_alloc();
 
     if( !command ) {
         return MONGO_ERROR;
@@ -1142,7 +1142,7 @@ MONGO_EXPORT void mongo_write_concern_destroy( mongo_write_concern *write_concer
 
     if( write_concern->cmd ) {
         bson_destroy( write_concern->cmd );
-        bson_dispose( write_concern->cmd );
+        bson_dealloc( write_concern->cmd );
         write_concern->cmd = NULL;
     }
 }
@@ -1282,7 +1282,7 @@ static int mongo_cursor_get_more( mongo_cursor *cursor ) {
 MONGO_EXPORT mongo_cursor *mongo_find( mongo *conn, const char *ns, const bson *query,
                                        const bson *fields, int limit, int skip, int options ) {
 
-    mongo_cursor *cursor = mongo_cursor_create();
+    mongo_cursor *cursor = mongo_cursor_alloc();
     mongo_cursor_init( cursor, conn, ns );
     cursor->flags |= MONGO_CURSOR_MUST_FREE;
 

--- a/src/mongo.h
+++ b/src/mongo.h
@@ -838,8 +838,8 @@ MONGO_EXPORT void mongo_cmd_reset_error( mongo *conn, const char *db );
 Utility API
 **********************************************************************/
 
-MONGO_EXPORT mongo* mongo_create( void );
-MONGO_EXPORT void mongo_dispose(mongo* conn);
+MONGO_EXPORT mongo* mongo_alloc( void );
+MONGO_EXPORT void mongo_dealloc(mongo* conn);
 MONGO_EXPORT int mongo_get_err(mongo* conn);
 MONGO_EXPORT int mongo_is_connected(mongo* conn);
 MONGO_EXPORT int mongo_get_op_timeout(mongo* conn);
@@ -847,10 +847,10 @@ MONGO_EXPORT const char* mongo_get_primary(mongo* conn);
 MONGO_EXPORT int mongo_get_socket(mongo* conn) ;
 MONGO_EXPORT int mongo_get_host_count(mongo* conn);
 MONGO_EXPORT const char* mongo_get_host(mongo* conn, int i);
-MONGO_EXPORT mongo_write_concern* mongo_write_concern_create( void );
-MONGO_EXPORT void mongo_write_concern_dispose(mongo_write_concern* write_concern);
-MONGO_EXPORT mongo_cursor* mongo_cursor_create( void );
-MONGO_EXPORT void mongo_cursor_dispose(mongo_cursor* cursor);
+MONGO_EXPORT mongo_write_concern* mongo_write_concern_alloc( void );
+MONGO_EXPORT void mongo_write_concern_dealloc(mongo_write_concern* write_concern);
+MONGO_EXPORT mongo_cursor* mongo_cursor_alloc( void );
+MONGO_EXPORT void mongo_cursor_dealloc(mongo_cursor* cursor);
 MONGO_EXPORT int  mongo_get_server_err(mongo* conn);
 MONGO_EXPORT const char*  mongo_get_server_err_string(mongo* conn);
 

--- a/test/bson_alloc_test.c
+++ b/test/bson_alloc_test.c
@@ -48,7 +48,7 @@ int test_bson_empty( void ) {
     ASSERT( bson_size(empty1) > 0 );
 
     ALLOW_AND_REQUIRE_MALLOC_BEGIN;
-    bson * empty2 = bson_create();
+    bson * empty2 = bson_alloc();
     ALLOW_AND_REQUIRE_MALLOC_END;
     memset( empty2, 0, sizeof( bson) );
     bson_init_empty( empty2 );
@@ -56,7 +56,7 @@ int test_bson_empty( void ) {
     ASSERT( bson_size( empty2 ) > 0 );
     bson_destroy( empty2 );
     ALLOW_AND_REQUIRE_FREE_BEGIN;
-    bson_dispose( empty2 );
+    bson_dealloc( empty2 );
     ALLOW_AND_REQUIRE_FREE_END;
 
     return 0;

--- a/test/gridfs_test.c
+++ b/test/gridfs_test.c
@@ -279,7 +279,7 @@ void test_random_write() {
 
         gridfile_writer_done(gfile);
         ASSERT(gfile->pos == j + n);
-        gridfile_dispose(gfile);
+        gridfile_dealloc(gfile);
         test_gridfile( gfs, data_before, j + n > i ? j + n : i, "input-buffer", "text/html" );
 
         /* Input from file */

--- a/test/write_concern_test.c
+++ b/test/write_concern_test.c
@@ -73,7 +73,7 @@ void test_batch_insert_with_continue( mongo *conn ) {
     mongo_create_simple_index( conn, TEST_NS, "n", MONGO_INDEX_UNIQUE, NULL );
 
     for( i=0; i<5; i++ ) {
-        objs[i] = bson_create();
+        objs[i] = bson_alloc();
         bson_init( objs[i] );
         bson_append_int( objs[i], "n", i );
         bson_finish( objs[i] );
@@ -86,14 +86,14 @@ void test_batch_insert_with_continue( mongo *conn ) {
           bson_shared_empty( ) ) == 5 );
 
     /* Add one duplicate value for n. */
-    objs2[0] = bson_create();
+    objs2[0] = bson_alloc();
     bson_init( objs2[0] );
     bson_append_int( objs2[0], "n", 1 );
     bson_finish( objs2[0] );
 
     /* Add n for 6 - 9. */
     for( i = 1; i < 5; i++ ) {
-        objs2[i] = bson_create();
+        objs2[i] = bson_alloc();
         bson_init( objs2[i] );
         bson_append_int( objs2[i], "n", i + 5 );
         bson_finish( objs2[i] );
@@ -113,10 +113,10 @@ void test_batch_insert_with_continue( mongo *conn ) {
 
     for( i=0; i<5; i++ ) {
         bson_destroy( objs2[i] );
-        bson_dispose( objs2[i] );
+        bson_dealloc( objs2[i] );
 
         bson_destroy( objs[i] );
-        bson_dispose( objs[i] );
+        bson_dealloc( objs[i] );
     }
 }
 
@@ -131,7 +131,7 @@ void test_update_and_remove( mongo *conn ) {
     create_capped_collection( conn );
 
     for( i=0; i<5; i++ ) {
-        objs[i] = bson_create();
+        objs[i] = bson_alloc();
         bson_init( objs[i] );
         bson_append_int( objs[i], "n", i );
         bson_finish( objs[i] );
@@ -182,7 +182,7 @@ void test_update_and_remove( mongo *conn ) {
     bson_destroy( update );
     for( i=0; i<5; i++ ) {
         bson_destroy( objs[i] );
-        bson_dispose( objs[i] );
+        bson_dealloc( objs[i] );
     }
 }
 


### PR DESCRIPTION
As discussed in recent pull requests, this helps to clarify that these functions merely allocate and deallocate memory, and helps clarify the difference between destroy and dealloc.

I left alone `gridfile_create`, which both allocates and initializes.

Note also that there is no `mongo_dealloc` – that's handled by `mongo_destroy`.
