### PR TITLE
GridFS chunk_new: Initialize with the amount of space needed

### DIFF
--- a/src/gridfs.c
+++ b/src/gridfs.c
@@ -100,7 +100,7 @@ static bson *chunk_new(bson_oid_t id, int chunkNumber, void** dataBuf, void* src
   if( preProcessChunk( dataBuf, &dataBufLen, srcData, len, flags) != 0 ) {
     return NULL;
   }
-  bson_init(b);
+  bson_init_size(b, dataBufLen + 128); /* a little space for field names, files_id, and n */
   bson_append_oid(b, "files_id", &id);
   bson_append_int(b, "n", chunkNumber);
   bson_append_binary(b, "data", BSON_BIN_BINARY, (char*)(*dataBuf), (int)dataBufLen);


### PR DESCRIPTION
This avoids automatically allocating about 1.5 x as much space as needed, as happens now on the call to `bson_append_binary`.
