### PR TITLE
GridFS: Minor refactoring

### DIFF
--- a/src/gridfs.c
+++ b/src/gridfs.c
@@ -215,7 +215,7 @@ MONGO_EXPORT void gridfs_destroy(gridfs *gfs) {
 
 /* gridfs accesors */
 
-MONGO_EXPORT bson_bool_t gridfs_get_caseInsensitive(gridfs *gfs){
+MONGO_EXPORT bson_bool_t gridfs_get_caseInsensitive( const gridfs *gfs ) {
   return gfs->caseInsensitive;
 }
 
@@ -436,7 +436,7 @@ MONGO_EXPORT void gridfs_remove_filename(gridfs *gfs, const char *filename) {
   mongo_cursor_destroy(files);
 }
 
-MONGO_EXPORT int gridfs_find_query(gridfs *gfs, bson *query, gridfile *gfile) {
+MONGO_EXPORT int gridfs_find_query( gridfs *gfs, const bson *query, gridfile *gfile ) {
 
   bson uploadDate = INIT_BSON;
   bson finalQuery = INIT_BSON;
@@ -501,7 +501,7 @@ static void gridfile_init_chunkSize(gridfile *gfile);
 
 /* gridfile constructors, destructors and memory management */
 
-MONGO_EXPORT int gridfile_init(gridfs *gfs, bson *meta, gridfile *gfile){
+MONGO_EXPORT int gridfile_init( gridfs *gfs, const bson *meta, gridfile *gfile ) {
   gfile->gfs = gfs;
   gfile->pos = 0;
   gfile->pending_len = 0;
@@ -676,7 +676,7 @@ MONGO_EXPORT const char *gridfile_get_filename( const gridfile *gfile ) {
   }
 }
 
-MONGO_EXPORT int gridfile_get_chunksize(gridfile *gfile) {
+MONGO_EXPORT int gridfile_get_chunksize( const gridfile *gfile ) {
   bson_iterator it = INIT_ITERATOR;
 
   if( gfile->chunkSize ) {
@@ -690,13 +690,13 @@ MONGO_EXPORT int gridfile_get_chunksize(gridfile *gfile) {
   }
 }
 
-MONGO_EXPORT gridfs_offset gridfile_get_contentlength(gridfile *gfile) {
+MONGO_EXPORT gridfs_offset gridfile_get_contentlength( const gridfile *gfile ) {
   gridfs_offset estimatedLen;
   estimatedLen = gfile->pending_len ? gfile->chunk_num * gridfile_get_chunksize( gfile ) + gfile->pending_len : gfile->length;
   return estimatedLen > gfile->length ? estimatedLen : gfile->length;  
 }
 
-MONGO_EXPORT const char *gridfile_get_contenttype(gridfile *gfile) {
+MONGO_EXPORT const char *gridfile_get_contenttype( const gridfile *gfile ) {
   bson_iterator it = INIT_ITERATOR;
 
   if (bson_find(&it, gfile->meta, "contentType")) {
@@ -706,7 +706,7 @@ MONGO_EXPORT const char *gridfile_get_contenttype(gridfile *gfile) {
   } 
 }
 
-MONGO_EXPORT bson_date_t gridfile_get_uploaddate(gridfile *gfile) {
+MONGO_EXPORT bson_date_t gridfile_get_uploaddate( const gridfile *gfile ) {
   bson_iterator it = INIT_ITERATOR;
 
   if( bson_find(&it, gfile->meta, "uploadDate") != BSON_EOO) {
@@ -716,7 +716,7 @@ MONGO_EXPORT bson_date_t gridfile_get_uploaddate(gridfile *gfile) {
   }
 }
 
-MONGO_EXPORT const char *gridfile_get_md5(gridfile *gfile) {
+MONGO_EXPORT const char *gridfile_get_md5( const gridfile *gfile ) {
   bson_iterator it = INIT_ITERATOR;
 
   if( bson_find(&it, gfile->meta, "md5") != BSON_EOO ) {
@@ -730,7 +730,7 @@ MONGO_EXPORT void gridfile_set_flags(gridfile *gfile, int flags){
   gfile->flags = flags;
 }
 
-MONGO_EXPORT int gridfile_get_flags(gridfile *gfile){
+MONGO_EXPORT int gridfile_get_flags( const gridfile *gfile ) {
   return gfile->flags;
 }
 
@@ -744,7 +744,7 @@ MONGO_EXPORT const char *gridfile_get_field(gridfile *gfile, const char *name) {
   }
 }
 
-MONGO_EXPORT bson_bool_t gridfile_get_boolean(gridfile *gfile, const char *name) {
+MONGO_EXPORT bson_bool_t gridfile_get_boolean( const gridfile *gfile, const char *name ) {
   bson_iterator it = INIT_ITERATOR;
 
   if( bson_find(&it, gfile->meta, name) != BSON_EOO) {
@@ -754,7 +754,7 @@ MONGO_EXPORT bson_bool_t gridfile_get_boolean(gridfile *gfile, const char *name)
   }
 }
 
-MONGO_EXPORT void gridfile_get_metadata(gridfile *gfile, bson *out, bson_bool_t copyData) {
+MONGO_EXPORT void gridfile_get_metadata( const gridfile *gfile, bson *out, bson_bool_t copyData ) {
   bson_iterator it = INIT_ITERATOR;
 
   if (bson_find(&it, gfile->meta, "metadata")) {
@@ -768,7 +768,7 @@ MONGO_EXPORT void gridfile_get_metadata(gridfile *gfile, bson *out, bson_bool_t 
 /* gridfile data management methods */
 /* ++++++++++++++++++++++++++++++++ */
 
-MONGO_EXPORT int gridfile_get_numchunks(gridfile *gfile) {
+MONGO_EXPORT int gridfile_get_numchunks( const gridfile *gfile ) {
   bson_iterator it = INIT_ITERATOR;
   gridfs_offset length;
   gridfs_offset chunkSize;

--- a/src/gridfs.h
+++ b/src/gridfs.h
@@ -169,7 +169,7 @@ MONGO_EXPORT void gridfs_remove_filename( gridfs *gfs, const char *filename );
  *
  *  @return MONGO_OK if successful, MONGO_ERROR otherwise
  */
-MONGO_EXPORT int gridfs_find_query( gridfs *gfs, bson *query, gridfile *gfile );
+MONGO_EXPORT int gridfs_find_query( gridfs *gfs, const bson *query, gridfile *gfile );
 
 /**
  *  Find the first file referenced by filename within the GridFS
@@ -190,7 +190,7 @@ MONGO_EXPORT int gridfs_find_filename( gridfs *gfs, const char *filename, gridfi
  *
  *  @return - MONGO_OK or MONGO_ERROR.
  */
-MONGO_EXPORT int gridfile_init( gridfs *gfs, bson *meta, gridfile *gfile );
+MONGO_EXPORT int gridfile_init( gridfs *gfs, const bson *meta, gridfile *gfile );
 
 /**
  *  Destroys the GridFile
@@ -203,7 +203,7 @@ MONGO_EXPORT void gridfile_destroy( gridfile *gfile );
  *  Returns whether or not the GridFile exists
  *  @param gfile - the GridFile being examined
  */
-MONGO_EXPORT bson_bool_t gridfile_exists( gridfile *gfile );
+MONGO_EXPORT bson_bool_t gridfile_exists( const gridfile *gfile );
 
 /**
  *  Returns the filename of GridFile
@@ -211,7 +211,7 @@ MONGO_EXPORT bson_bool_t gridfile_exists( gridfile *gfile );
  *
  *  @return - the filename of the Gridfile
  */
-MONGO_EXPORT const char *gridfile_get_filename( gridfile *gfile );
+MONGO_EXPORT const char *gridfile_get_filename( const gridfile *gfile );
 
 /**
  *  Returns the size of the chunks of the GridFile
@@ -219,7 +219,7 @@ MONGO_EXPORT const char *gridfile_get_filename( gridfile *gfile );
  *
  *  @return - the size of the chunks of the Gridfile
  */
-MONGO_EXPORT int gridfile_get_chunksize( gridfile *gfile );
+MONGO_EXPORT int gridfile_get_chunksize( const gridfile *gfile );
 
 /**
  *  Returns the length of GridFile's data
@@ -228,7 +228,7 @@ MONGO_EXPORT int gridfile_get_chunksize( gridfile *gfile );
  *
  *  @return - the length of the Gridfile's data
  */
-MONGO_EXPORT gridfs_offset gridfile_get_contentlength( gridfile *gfile );
+MONGO_EXPORT gridfs_offset gridfile_get_contentlength( const gridfile *gfile );
 
 /**
  *  Returns the MIME type of the GridFile
@@ -238,7 +238,7 @@ MONGO_EXPORT gridfs_offset gridfile_get_contentlength( gridfile *gfile );
  *  @return - the MIME type of the Gridfile
  *            (NULL if no type specified)
  */
-MONGO_EXPORT const char *gridfile_get_contenttype( gridfile *gfile );
+MONGO_EXPORT const char *gridfile_get_contenttype( const gridfile *gfile );
 
 /**
  *  Returns the upload date of GridFile
@@ -247,7 +247,7 @@ MONGO_EXPORT const char *gridfile_get_contenttype( gridfile *gfile );
  *
  *  @return - the upload date of the Gridfile
  */
-MONGO_EXPORT bson_date_t gridfile_get_uploaddate( gridfile *gfile );
+MONGO_EXPORT bson_date_t gridfile_get_uploaddate( const gridfile *gfile );
 
 /**
  *  Returns the MD5 of GridFile
@@ -256,7 +256,7 @@ MONGO_EXPORT bson_date_t gridfile_get_uploaddate( gridfile *gfile );
  *
  *  @return - the MD5 of the Gridfile
  */
-MONGO_EXPORT const char *gridfile_get_md5( gridfile *gfile );
+MONGO_EXPORT const char *gridfile_get_md5( const gridfile *gfile );
 
 /**
  *  Returns the _id in GridFile specified by name
@@ -285,7 +285,7 @@ MONGO_EXPORT const char *gridfile_get_field( gridfile *gfile,
  *
  *  @return - the caseInsensitive flag of the gfs
  */
-MONGO_EXPORT bson_bool_t gridfs_get_caseInsensitive(gridfs *gfs);
+MONGO_EXPORT bson_bool_t gridfs_get_caseInsensitive( const gridfs *gfs );
 
 /**
  *  Sets the caseInsensitive flag value of gfs
@@ -311,7 +311,7 @@ MONGO_EXPORT void gridfile_set_flags(gridfile *gfile, int flags);
   *
  *  @return - void
  */
-MONGO_EXPORT int gridfile_get_flags(gridfile *gfile);
+MONGO_EXPORT int gridfile_get_flags( const gridfile *gfile );
 
 /**
  *  Returns a boolean field in GridFile specified by name
@@ -321,7 +321,7 @@ MONGO_EXPORT int gridfile_get_flags(gridfile *gfile);
  *  @return - the boolean of the field specified
  *            (NULL if none exists)
  */
-MONGO_EXPORT bson_bool_t gridfile_get_boolean( gridfile *gfile,
+MONGO_EXPORT bson_bool_t gridfile_get_boolean( const gridfile *gfile,
                                   const char *name );
 
 /**
@@ -338,7 +338,7 @@ MONGO_EXPORT bson_bool_t gridfile_get_boolean( gridfile *gfile,
  *  @param copyData when true, makes a copy of the scope data which will remain
  *    valid when the grid file is deallocated.
  */
-MONGO_EXPORT void gridfile_get_metadata( gridfile *gfile, bson* metadata, bson_bool_t copyData );
+MONGO_EXPORT void gridfile_get_metadata( const gridfile *gfile, bson* metadata, bson_bool_t copyData );
 
 /**
  *  Returns the number of chunks in the GridFile
@@ -346,7 +346,7 @@ MONGO_EXPORT void gridfile_get_metadata( gridfile *gfile, bson* metadata, bson_b
  *
  *  @return - the number of chunks in the Gridfile
  */
-MONGO_EXPORT int gridfile_get_numchunks( gridfile *gfile );
+MONGO_EXPORT int gridfile_get_numchunks( const gridfile *gfile );
 
 /**
  *  Returns chunk n of GridFile

--- a/src/gridfs.h
+++ b/src/gridfs.h
@@ -265,7 +265,7 @@ MONGO_EXPORT const char *gridfile_get_md5( gridfile *gfile );
  * 
  *  @return - the _id field in metadata
  */
-MONGO_EXPORT bson_oid_t *gridfile_get_id(gridfile *gfile);
+MONGO_EXPORT bson_oid_t gridfile_get_id( const gridfile *gfile );
 
 /**
  *  Returns the field in GridFile specified by name

--- a/src/gridfs.h
+++ b/src/gridfs.h
@@ -38,9 +38,6 @@ typedef struct {
     bson_bool_t caseInsensitive; /**. If true then files are matched in case insensitive fashion */
 } gridfs;
 
-#define GRIDFILE_DEFAULT 0
-#define GRIDFILE_NOMD5 1 
-
 /* A GridFile is a single GridFS file. */
 typedef struct {
     gridfs *gfs;        /**> The GridFS where the GridFile is located */
@@ -56,6 +53,11 @@ typedef struct {
     int flags;          /**> Store here special flags such as: No MD5 calculation and Zlib Compression enabled*/
     int chunkSize;   /**> Let's cache here the cache size to avoid accesing it on the Meta mongo object every time is needed */
 } gridfile;
+
+enum gridfile_storage_type {
+    GRIDFILE_DEFAULT = 0,
+    GRIDFILE_NOMD5 = ( 1<<0 )
+};
 
 #define INIT_GRIDFILE  {NULL}
 


### PR DESCRIPTION
- Change return type of `gridfile_get_oid` for convenience
- Add const qualifiers
- Refactor `gridfs_init` and `gridfs_destroy`
- Minor formatting changes
