### PR TITLE
GridFS: Restore Gary's version of upperFileName

### DIFF
--- a/src/gridfs.c
+++ b/src/gridfs.c
@@ -28,6 +28,7 @@
 #include <assert.h>
 
 #ifndef _MSC_VER
+#include <ctype.h>
 char *_strupr(char *str)
 {
    char *s = str;
@@ -224,12 +225,10 @@ MONGO_EXPORT void gridfs_set_caseInsensitive(gridfs *gfs, bson_bool_t newValue){
   gfs->caseInsensitive = newValue;
 }
 
-static char* upperFileName(const char* filename){
-  char *upperName = (char*) bson_malloc((int)strlen( filename ) + 1 );
-  const char *in = filename;
-  char *out = upperName;
-  while (*in) *out++ = (char)toupper(*in++);
-  *out = *in;
+static char* upperFileName(const char* filename) {
+  char* upperName = (char*) bson_malloc((int)strlen( filename ) + 1 );
+  strcpy(upperName, filename);
+  _strupr(upperName);
   return upperName;
 }
 

--- a/src/gridfs.h
+++ b/src/gridfs.h
@@ -60,10 +60,8 @@ typedef struct {
 #define INIT_GRIDFILE  {NULL}
 
 #ifndef _MSC_VER
-#include <ctype.h>
 char *_strupr(char *str);
 char *_strlwr(char *str);
-#define _unlink unlink
 #endif
 
 typedef int ( *gridfs_preProcessingFunc )( void** targetBuf, size_t* targetLen, void* srcBuf, size_t srcLen, int flags );


### PR DESCRIPTION
This puts back Gary's version of upperFileName which was clobbered when pull request #106 was merged.

It also moves `#include <ctype.h>` to `gridfs.c`, the only place it's needed, and removes `_unlink` which is being handled in `gridfs_test.c`.
