### PR TITLE
Refactored methods which dealed directly with gridfile contents instead ...

### DIFF
--- a/src/gridfs.h
+++ b/src/gridfs.h
@@ -98,6 +98,23 @@ MONGO_EXPORT int gridfs_init( mongo *client, const char *dbname,
 MONGO_EXPORT void gridfs_destroy( gridfs *gfs );
 
 /**
+ *  Initializes a GridFile containing the GridFS and file bson
+ *  @param gfs - the GridFS where the GridFile is located
+ *  @param meta - the file object
+ *  @param gfile - the output GridFile that is being initialized
+ *
+ *  @return - MONGO_OK or MONGO_ERROR.
+ */
+MONGO_EXPORT int gridfile_init( gridfs *gfs, bson *meta, gridfile *gfile );
+
+/**
+ *  Destroys the GridFile
+ *
+ *  @param oGridFIle - the GridFile being destroyed
+ */
+MONGO_EXPORT void gridfile_destroy( gridfile *gfile );
+
+/**
  *  Initializes a gridfile for writing incrementally with gridfs_write_buffer.
  *  Once initialized, you can write any number of buffers with gridfs_write_buffer.
  *  When done, you must call gridfs_writer_done to save the file metadata.
@@ -114,7 +131,7 @@ MONGO_EXPORT void gridfile_writer_init( gridfile *gfile, gridfs *gfs, const char
  *  stream to a GridFS file. When finished, be sure to call gridfs_writer_done.
  *
  */
-MONGO_EXPORT void gridfile_write_buffer( gridfile *gfile, const char *data,
+MONGO_EXPORT gridfs_offset gridfile_write_buffer( gridfile *gfile, const char *data,
         gridfs_offset length );
 
 /**
@@ -181,23 +198,6 @@ MONGO_EXPORT int gridfs_find_query( gridfs *gfs, bson *query, gridfile *gfile );
  *  @return MONGO_OK or MONGO_ERROR.
  */
 MONGO_EXPORT int gridfs_find_filename( gridfs *gfs, const char *filename, gridfile *gfile );
-
-/**
- *  Initializes a GridFile containing the GridFS and file bson
- *  @param gfs - the GridFS where the GridFile is located
- *  @param meta - the file object
- *  @param gfile - the output GridFile that is being initialized
- *
- *  @return - MONGO_OK or MONGO_ERROR.
- */
-MONGO_EXPORT int gridfile_init( gridfs *gfs, bson *meta, gridfile *gfile );
-
-/**
- *  Destroys the GridFile
- *
- *  @param oGridFIle - the GridFile being destroyed
- */
-MONGO_EXPORT void gridfile_destroy( gridfile *gfile );
 
 /**
  *  Returns whether or not the GridFile exists

--- a/src/gridfs.h
+++ b/src/gridfs.h
@@ -129,7 +129,11 @@ MONGO_EXPORT void gridfile_writer_init( gridfile *gfile, gridfs *gfs, const char
  *  Write to a GridFS file incrementally. You can call this function any number
  *  of times with a new buffer each time. This allows you to effectively
  *  stream to a GridFS file. When finished, be sure to call gridfs_writer_done.
- *
+ * 
+ *  @param gfile - GridFile to write to
+ *  @param data - Pointer to buffer with data to be written
+ *  @param length - Size of buffer with data to be written
+ *  @return - Number of bytes written. If different from length assume somethind went wrong
  */
 MONGO_EXPORT gridfs_offset gridfile_write_buffer( gridfile *gfile, const char *data,
         gridfs_offset length );

--- a/test/gridfs_test.c
+++ b/test/gridfs_test.c
@@ -206,8 +206,8 @@ void test_streaming( void ) {
     gridfile_init( gfs, NULL, gfile );
     gridfile_writer_init( gfile, gfs, "medium", "text/html", GRIDFILE_DEFAULT );
 
-    gridfile_write_buffer( gfile, medium, MEDIUM );
-    gridfile_write_buffer( gfile, medium + MEDIUM, MEDIUM );
+    ASSERT( gridfile_write_buffer( gfile, medium, MEDIUM ) == MEDIUM);
+    ASSERT( gridfile_write_buffer( gfile, medium + MEDIUM, MEDIUM ) == MEDIUM);
     gridfile_writer_done( gfile );
     test_gridfile( gfs, medium, 2 * MEDIUM, "medium", "text/html" );
     gridfs_destroy( gfs );
@@ -222,7 +222,7 @@ void test_streaming( void ) {
     gridfs_remove_filename( gfs, "large" );
     gridfile_writer_init( gfile, gfs, "large", "text/html", GRIDFILE_DEFAULT );
     for( n=0; n < ( LARGE / 1024 ); n++ ) {
-        gridfile_write_buffer( gfile, buf + ( n * 1024 ), 1024 );
+        ASSERT( gridfile_write_buffer( gfile, buf + ( n * 1024 ), 1024 ) == 1024 );
     }
     gridfile_writer_done( gfile );
     test_gridfile( gfs, buf, LARGE, "large", "text/html" );
@@ -278,9 +278,9 @@ void test_random_write() {
         gridfile_writer_init(gfile, gfs, "input-buffer", "text/html", GRIDFILE_DEFAULT );
         gridfile_seek(gfile, j); // Seek into the same buffer position within the GridFS file
         if ( bytes_to_write_first ) {
-          gridfile_write_buffer(gfile, random_data, bytes_to_write_first); // Let's write 10 bytes first, and later the rest
+          ASSERT( gridfile_write_buffer(gfile, random_data, bytes_to_write_first) == bytes_to_write_first ); // Let's write 10 bytes first, and later the rest
         }
-        gridfile_write_buffer(gfile, &random_data[bytes_to_write_first], n - bytes_to_write_first); // Try to write to the existing GridFS file on the position given by j
+        ASSERT( gridfile_write_buffer(gfile, &random_data[bytes_to_write_first], n - bytes_to_write_first) == n - bytes_to_write_first ); // Try to write to the existing GridFS file on the position given by j
         gridfile_seek(gfile, j);
         gridfile_read( gfile, n, buf );
         ASSERT(memcmp( buf, &data_before[j], n) == 0);
@@ -365,7 +365,7 @@ void test_random_write2( void ) {
        given the fact 256K is not a multiple of 3072. Let's stress the buffering logic a little bit */
     for( n = LARGE / 3072 - 1; n >= 0; n-- ) {
         gridfile_seek( gfile, 3072 * n );
-        gridfile_write_buffer( gfile, buf + ( n * 3072 ), 3072 );
+        ASSERT( gridfile_write_buffer( gfile, buf + ( n * 3072 ), 3072 ) == 3072 );
     }
     gridfile_writer_done( gfile );
     test_gridfile( gfs, buf, LARGE, "random_access", "text/html" );
@@ -452,7 +452,7 @@ void test_large( void ) {
     fd = fopen( "bigfile", "r" );
     i = 0;
     while( ( n = fread( buffer, 1, READ_WRITE_BUF_SIZE, fd ) ) != 0 ) {
-        gridfile_write_buffer( gfile, buffer, n );     
+        ASSERT( gridfile_write_buffer( gfile, buffer, n ) == n );     
         if(i++ % 10 == 0) {
           bson_init( &lastErrorCmd );
           bson_append_int( &lastErrorCmd, "getLastError", 1);

--- a/test/gridfs_test.c
+++ b/test/gridfs_test.c
@@ -179,12 +179,12 @@ void test_delete( void ) {
     gridfs gfs[1];
     gridfile gfile[1];
     char *data = (char*)bson_malloc( 1024 );
+    const char *testFile = "test-delete";
 
     INIT_SOCKETS_FOR_WINDOWS;
     CONN_CLIENT_TEST;
     GFS_INIT;
 
-    const char *testFile = "test-delete";
     ASSERT( gridfs_store_buffer( gfs, data, 1024, testFile, "text/html", GRIDFILE_DEFAULT ) == MONGO_OK );
     ASSERT( gridfs_find_filename( gfs, testFile, gfile ) == MONGO_OK );
     gridfile_destroy( gfile );


### PR DESCRIPTION
...of using gridfile object. This refactoring is needed in order to later refactore pre and post processing of chunks logic to optimize buffer allocation and prepare the ground for effective usage of pre and post processing for encryption, which requires keeping a context between calls
