### PR TITLE
Minor GridFS changes

### DIFF
--- a/src/gridfs.c
+++ b/src/gridfs.c
@@ -556,7 +556,7 @@ static void gridfile_init_flags(gridfile *gfile) {
   }
 }
 
-MONGO_EXPORT void gridfile_writer_init(gridfile *gfile, gridfs *gfs, const char *remote_name, const char *content_type, int flags ) {
+MONGO_EXPORT int gridfile_writer_init(gridfile *gfile, gridfs *gfs, const char *remote_name, const char *content_type, int flags ) {
   gridfile tmpFile = INIT_GRIDFILE;
 
   gfile->gfs = gfs;
@@ -599,6 +599,8 @@ MONGO_EXPORT void gridfile_writer_init(gridfile *gfile, gridfs *gfs, const char 
   /* Let's pre-allocate DEFAULT_CHUNK_SIZE bytes into pending_data then we don't need to worry 
      about doing realloc everywhere we want use the pending_data buffer */
   gfile->pending_data = (char*) bson_malloc((int)gridfs_pending_data_size(gfile->flags));
+
+  return MONGO_OK;
 }
 
 MONGO_EXPORT void gridfile_destroy(gridfile *gfile) {

--- a/src/gridfs.h
+++ b/src/gridfs.h
@@ -104,8 +104,8 @@ MONGO_EXPORT void gridfs_destroy( gridfs *gfs );
  *  +-+-+-+-  when using this function
  *
  */
-MONGO_EXPORT void gridfile_writer_init( gridfile *gfile, gridfs *gfs, const char *remote_name,
-                                        const char *content_type, int flags );
+MONGO_EXPORT int gridfile_writer_init( gridfile *gfile, gridfs *gfs, const char *remote_name,
+                                       const char *content_type, int flags );
 
 /**
  *  Write to a GridFS file incrementally. You can call this function any number

--- a/src/gridfs.h
+++ b/src/gridfs.h
@@ -153,10 +153,14 @@ MONGO_EXPORT int gridfs_store_file( gridfs *gfs, const char *filename,
 
 /**
  *  Removes the files referenced by filename from the db
+ *
  *  @param gfs - the working GridFS
  *  @param filename - the filename of the file/s to be removed
+ *
+ *  @return MONGO_OK if a matching file was removed, and MONGO_ERROR if
+ *    an error occurred or the file did not exist
  */
-MONGO_EXPORT void gridfs_remove_filename( gridfs *gfs, const char *filename );
+MONGO_EXPORT int gridfs_remove_filename( gridfs *gfs, const char *filename );
 
 /**
  *  Find the first file matching the provided query within the

--- a/test/gridfs_test.c
+++ b/test/gridfs_test.c
@@ -26,6 +26,9 @@
 #define gridfs_test_unlink unlink
 #endif
 
+#define GFS_INIT \
+    gridfs_init( conn, "test", "fs", gfs )
+
 void fill_buffer_randomly( char *data, int64_t length ) {
     int64_t i;
     int random;
@@ -139,13 +142,8 @@ void test_basic( void ) {
     srand((unsigned int) time( NULL ) );
 
     INIT_SOCKETS_FOR_WINDOWS;
-
-    if ( mongo_client( conn, TEST_SERVER, 27017 ) ) {
-        printf( "failed to connect 2\n" );
-        exit( 1 );
-    }
-
-    gridfs_init( conn, "test", "fs", gfs );
+    CONN_CLIENT_TEST;
+    GFS_INIT;
 
     fill_buffer_randomly( data_before, UPPER );
     for ( i = LOWER; i <= UPPER; i += DELTA ) {
@@ -203,7 +201,7 @@ void test_streaming( void ) {
     fill_buffer_randomly( small, ( int64_t )LOWER );
     fill_buffer_randomly( buf, ( int64_t )LARGE );
 
-    gridfs_init( conn, "test", "fs", gfs );
+    GFS_INIT;
     gridfile_init( gfs, NULL, gfile );
     gridfile_writer_init( gfile, gfs, "medium", "text/html", GRIDFILE_DEFAULT );
 
@@ -213,13 +211,12 @@ void test_streaming( void ) {
     test_gridfile( gfs, medium, 2 * MEDIUM, "medium", "text/html" );
     gridfs_destroy( gfs );
 
-    gridfs_init( conn, "test", "fs", gfs );
-
+    GFS_INIT;
     gridfs_store_buffer( gfs, small, LOWER, "small", "text/html", GRIDFILE_DEFAULT );
     test_gridfile( gfs, small, LOWER, "small", "text/html" );
     gridfs_destroy( gfs );
 
-    gridfs_init( conn, "test", "fs", gfs );
+    GFS_INIT;
     gridfs_remove_filename( gfs, "large" );
     gridfile_writer_init( gfile, gfs, "large", "text/html", GRIDFILE_DEFAULT );
     for( n=0; n < ( LARGE / 1024 ); n++ ) {
@@ -248,14 +245,8 @@ void test_random_write() {
     srand((unsigned int) time( NULL ) );
 
     INIT_SOCKETS_FOR_WINDOWS;
-
-    if ( mongo_client( conn, TEST_SERVER, 27017 ) ) {
-        printf( "failed to connect 2\n" );
-        exit( 1 );
-    }
-
-    gridfs_init( conn, "test", "fs", gfs );
-
+    GFS_INIT;
+    
     fill_buffer_randomly( data_before, UPPER );
     fill_buffer_randomly( random_data, UPPER );
     for ( i = LOWER; i <= UPPER; i += DELTA ) {
@@ -339,7 +330,7 @@ void test_random_write2( void ) {
 
     bson_init_empty( &meta );
 
-    gridfs_init( conn, "test", "fs", gfs );
+    GFS_INIT;
 
     /* This portion of the test we will write zeroes by using new API gridfile_set_size
        function gridfile_expand tested implicitally by using gridfile_set_size making file larger */
@@ -404,8 +395,7 @@ void test_large( void ) {
     mongo_write_concern_finish(&wc);
     mongo_set_write_concern(conn, &wc);
 
-
-    gridfs_init( conn, "test", "fs", gfs );
+    GFS_INIT;
 
     fd = fopen( "bigfile", "r" );
     if( fd ) {


### PR DESCRIPTION
- Add return value to `gridfs_remove_filename`
- Add return value to `gridfile_writer_init` (which eventually should be meaningful)
- Stop writing when encountering an error
- In tests, Add macro for gridfs_init
- Minor refactoring and compilation fixes
