### PR TITLE
Replaced usage of size_t for SOCKET. SOCKET in Windows is the standard s...

### DIFF
--- a/src/env.c
+++ b/src/env.c
@@ -284,17 +284,16 @@ int mongo_env_set_socket_op_timeout( mongo *conn, int millis ) {
 
 static int mongo_env_unix_socket_connect( mongo *conn, const char *sock_path ) {
     struct sockaddr_un addr;
-    int sock, status, len;
+    int status, len;
 
     conn->connected = 0;
 
-    sock = socket( AF_UNIX, SOCK_STREAM, 0 );
+    conn->sock = socket( AF_UNIX, SOCK_STREAM, 0 );
 
-    if ( sock == INVALID_SOCKET ) {
+    if ( conn->sock == INVALID_SOCKET ) {
         return MONGO_ERROR;
     }
-
-    conn->sock = sock;
+    
     addr.sun_family = AF_UNIX;
     strncpy( addr.sun_path, sock_path, sizeof(addr.sun_path) - 1 );
     len = sizeof( addr );
@@ -314,7 +313,7 @@ static int mongo_env_unix_socket_connect( mongo *conn, const char *sock_path ) {
 
 int mongo_env_socket_connect( mongo *conn, const char *host, int port ) {
     char port_str[NI_MAXSERV];
-    int sock, status;
+    int status;
 
     struct addrinfo ai_hints;
     struct addrinfo *ai_list = NULL;
@@ -345,12 +344,11 @@ int mongo_env_socket_connect( mongo *conn, const char *host, int port ) {
     }
 
     for ( ai_ptr = ai_list; ai_ptr != NULL; ai_ptr = ai_ptr->ai_next ) {
-        sock = socket( ai_ptr->ai_family, ai_ptr->ai_socktype, ai_ptr->ai_protocol );
-        if ( sock == INVALID_SOCKET ) {
+        conn->sock = socket( ai_ptr->ai_family, ai_ptr->ai_socktype, ai_ptr->ai_protocol );
+        if ( conn->sock == INVALID_SOCKET ) {
             continue;
         }
-
-        conn->sock = sock;
+        
         status = connect( conn->sock, ai_ptr->ai_addr, ai_ptr->ai_addrlen );
         if ( status != 0 ) {
             mongo_env_close_socket( conn->sock );

--- a/src/env.c
+++ b/src/env.c
@@ -22,19 +22,19 @@
 #include <string.h>
 
 #ifdef _MSC_VER
-#include <ws2tcpip.h>  /* send,recv,socklen_t etc */
-#include <wspiapi.h>   /* addrinfo */
+  #include <ws2tcpip.h>  /* send,recv,socklen_t etc */
+  #include <wspiapi.h>   /* addrinfo */
 #else
-#include <ws2tcpip.h>  /* send,recv,socklen_t etc */
-#include <winsock2.h>
-typedef int socklen_t;
+  #include <ws2tcpip.h>  /* send,recv,socklen_t etc */
+  #include <winsock2.h>
+  typedef int socklen_t;
 #endif
 
 #ifndef NI_MAXSERV
 # define NI_MAXSERV 32
 #endif
 
-int mongo_env_close_socket( size_t socket ) {
+int mongo_env_close_socket( SOCKET socket ) {
     return closesocket( socket );
 }
 
@@ -120,7 +120,7 @@ int mongo_env_socket_connect( mongo *conn, const char *host, int port ) {
         conn->sock = socket( ai_ptr->ai_family, ai_ptr->ai_socktype,
                              ai_ptr->ai_protocol );
 
-        if ( conn->sock < 0 ) {
+        if ( conn->sock == INVALID_SOCKET ) {
             __mongo_set_error( conn, MONGO_SOCKET_ERROR, "socket() failed",
                                WSAGetLastError() );
             conn->sock = 0;
@@ -217,7 +217,7 @@ MONGO_EXPORT int mongo_env_sock_init( void ) {
 # define NI_MAXSERV 32
 #endif
 
-int mongo_env_close_socket( size_t socket ) {
+int mongo_env_close_socket( SOCKET socket ) {
     return close( socket );
 }
 
@@ -290,7 +290,7 @@ static int mongo_env_unix_socket_connect( mongo *conn, const char *sock_path ) {
 
     sock = socket( AF_UNIX, SOCK_STREAM, 0 );
 
-    if ( sock < 0 ) {
+    if ( sock == INVALID_SOCKET ) {
         return MONGO_ERROR;
     }
 
@@ -346,7 +346,7 @@ int mongo_env_socket_connect( mongo *conn, const char *host, int port ) {
 
     for ( ai_ptr = ai_list; ai_ptr != NULL; ai_ptr = ai_ptr->ai_next ) {
         sock = socket( ai_ptr->ai_family, ai_ptr->ai_socktype, ai_ptr->ai_protocol );
-        if ( sock < 0 ) {
+        if ( sock == INVALID_SOCKET ) {
             continue;
         }
 
@@ -435,7 +435,7 @@ typedef int socklen_t;
 # define NI_MAXSERV 32
 #endif
 
-int mongo_env_close_socket( size_t socket ) {
+int mongo_env_close_socket( SOCKET socket ) {
 #ifdef _WIN32
     return closesocket( socket );
 #else
@@ -495,7 +495,7 @@ int mongo_env_socket_connect( mongo *conn, const char *host, int port ) {
     socklen_t addressSize;
     int flag = 1;
 
-    if ( ( conn->sock = socket( AF_INET, SOCK_STREAM, 0 ) ) < 0 ) {
+    if ( ( conn->sock = socket( AF_INET, SOCK_STREAM, 0 ) ) == INVALID_SOCKET ) {
         conn->sock = 0;
         conn->err = MONGO_CONN_NO_SOCKET;
         return MONGO_ERROR;
@@ -507,7 +507,7 @@ int mongo_env_socket_connect( mongo *conn, const char *host, int port ) {
     sa.sin_addr.s_addr = inet_addr( host );
     addressSize = sizeof( sa );
 
-    if ( connect( conn->sock, ( struct sockaddr * )&sa, addressSize ) == -1 ) {
+    if ( connect( conn->sock, ( struct sockaddr * )&sa, addressSize ) == INVALID_SOCKET ) {
         mongo_env_close_socket( conn->sock );
         conn->connected = 0;
         conn->sock = 0;

--- a/src/env.h
+++ b/src/env.h
@@ -23,6 +23,10 @@
 
 MONGO_EXTERN_C_START
 
+#if !defined(MONGO_ENV_STANDARD) && (defined(__APPLE__) || defined(__linux) || defined(__unix) || defined(__posix))
+  #define INVALID_SOCKET (-1) 
+#endif
+
 /* This is a no-op in the generic implementation. */
 int mongo_env_set_socket_op_timeout( mongo *conn, int millis );
 int mongo_env_read_socket( mongo *conn, void *buf, size_t len );
@@ -33,7 +37,7 @@ int mongo_env_socket_connect( mongo *conn, const char *host, int port );
 MONGO_EXPORT int mongo_env_sock_init( void );
 
 /* Close a socket */
-MONGO_EXPORT int mongo_env_close_socket( size_t socket );
+MONGO_EXPORT int mongo_env_close_socket( SOCKET socket );
 
 MONGO_EXTERN_C_END
 #endif

--- a/src/mongo.c
+++ b/src/mongo.c
@@ -65,7 +65,7 @@ MONGO_EXPORT const char* mongo_get_primary(mongo* conn) {
 }
 
 
-MONGO_EXPORT size_t mongo_get_socket(mongo* conn) {
+MONGO_EXPORT SOCKET mongo_get_socket(mongo* conn) {
     mongo* conn_ = (mongo*)conn;
     return conn_->sock;
 }

--- a/src/mongo.h
+++ b/src/mongo.h
@@ -25,6 +25,13 @@
 
 MONGO_EXTERN_C_START
 
+#if !defined(MONGO_ENV_STANDARD) && (defined(__APPLE__) || defined(__linux) || defined(__unix) || defined(__posix))
+  typedef int SOCKET; 
+#else
+  typedef size_t SOCKET; /* Defined socket as size_t to avoid coupling here with Winsock header files. It creates other issues in other files because 
+                            of redefined types that are used on .c files */
+#endif
+
 #define MONGO_MAJOR 0
 #define MONGO_MINOR 7
 #define MONGO_PATCH 0
@@ -163,7 +170,7 @@ typedef struct {
 typedef struct mongo {
     mongo_host_port *primary;  /**< Primary connection info. */
     mongo_replica_set *replica_set;    /**< replica_set object if connected to a replica set. */
-    size_t sock;                  /**< Socket file descriptor. */
+    SOCKET sock;                  /**< Socket file descriptor. */
     int flags;                 /**< Flags on this connection object. */
     int conn_timeout_ms;       /**< Connection timeout in milliseconds. */
     int op_timeout_ms;         /**< Read and write timeout in milliseconds. */
@@ -864,7 +871,7 @@ MONGO_EXPORT int mongo_get_err(mongo* conn);
 MONGO_EXPORT int mongo_is_connected(mongo* conn);
 MONGO_EXPORT int mongo_get_op_timeout(mongo* conn);
 MONGO_EXPORT const char* mongo_get_primary(mongo* conn);
-MONGO_EXPORT size_t mongo_get_socket(mongo* conn) ;
+MONGO_EXPORT SOCKET mongo_get_socket(mongo* conn) ;
 MONGO_EXPORT int mongo_get_host_count(mongo* conn);
 MONGO_EXPORT const char* mongo_get_host(mongo* conn, int i);
 MONGO_EXPORT mongo_write_concern* mongo_write_concern_alloc( void );


### PR DESCRIPTION
...ocket type as defined in Winsock2 while on x systems is a regular int.

Defined INVALID_SOCKET as -1 for x systems, while in Windows is the standard defined value for error when trying to create a socket
