### PR TITLE
Address initialization problems.  Some minor fixes as I went.

### DIFF
--- a/src/bson.h
+++ b/src/bson.h
@@ -133,22 +133,19 @@ typedef struct {
     bson_bool_t first;
 } bson_iterator;
 
-#define INIT_ITERATOR {NULL, 0}
-
 typedef struct {
-    char *data;    /**< Pointer to a block of data in this BSON object. */
-    char *cur;     /**< Pointer to the current position. */
-    int dataSize;  /**< The number of bytes allocated to char *data. */
+    char *data;           /**< Pointer to a block of data in this BSON object. */
+    char *cur;            /**< Pointer to the current position. */
+    int dataSize;         /**< The number of bytes allocated to char *data. */
     bson_bool_t finished; /**< When finished, the BSON object can no longer be modified. */
     bson_bool_t ownsData; /**< Whether destroying this object will deallocate its data block */
-    size_t stack[32];     /**< A stack used to keep track of nested BSON elements.*/
-    int stackPos;         /**< Index of current stack position. */
-    int err; /**< Bitfield representing errors or warnings on this buffer */
-    size_t * stackPtr;    /**< Pointer to the current stack */
+    int err;              /**< Bitfield representing errors or warnings on this buffer */
     int stackSize;        /**< Number of elements in the current stack */
+    int stackPos;         /**< Index of current stack position. */
+    size_t* stackPtr;     /**< Pointer to the current stack */
+    size_t stack[32];     /**< A stack used to keep track of nested BSON elements.
+                               Must be at end of bson struct so _bson_zero does not clear. */
 } bson;
-
-#define INIT_BSON {NULL, NULL}
 
 #pragma pack(1)
 typedef union {
@@ -178,6 +175,18 @@ typedef struct {
  * @return a new BSON object.
  */
 MONGO_EXPORT bson* bson_alloc( void );
+
+/**
+ * Zero a bson struct.  All fields are set to zero except the stack.
+ *
+ * @note Mainly used internally, but can be called for safety
+ *       purposes so that a later call to bson_destroy() doesn't flip out.
+ *       It is safe to call this function on a NULL pointer in which case
+ *       there is no effect.
+ * @param b the BSON object to zero.
+ *
+ */
+MONGO_EXPORT void bson_init_zero( bson *b );
 
 /**
  * Deallocate a BSON object.
@@ -225,7 +234,7 @@ int bson_init_finished_data_with_copy( bson *b, const char *data );
 MONGO_EXPORT int bson_size( const bson *b );
 
 /**
- * Minimum finished size of an unfinished BSON object.
+ * Minimum finished size of an unfinished BSON object given current contents.
  *
  * @param b the BSON object.
  *
@@ -246,6 +255,17 @@ MONGO_EXPORT void bson_print( const bson *b );
  * @param b a BSON object
  */
 MONGO_EXPORT const char *bson_data( const bson *b );
+
+/**
+ * Returns true if bson_data(b) {b->data} is not null; else, false.
+ *
+ * @note Convenience function for determining if bson data was returned by a function.
+ *       Check required after calls to mongo_create_index(), mongo_create_simple_index(),
+ *       mongo_cmd_get_last_error() and mongo_cmd_get_prev_error().
+ * @param b the bson struct to inspect.
+ */
+
+MONGO_EXPORT int bson_has_data( const bson *b );
 
 /**
  * Print a string representation of a BSON object.

--- a/src/gridfs.c
+++ b/src/gridfs.c
@@ -131,7 +131,7 @@ static void chunk_free(bson *oChunk) {
 /* gridfs constructor */
 MONGO_EXPORT int gridfs_init(mongo *client, const char *dbname, const char *prefix, gridfs *gfs) {
 
-  bson b = INIT_BSON;
+  bson b;
 
   gfs->caseInsensitive = 0;
   gfs->client = client;
@@ -232,68 +232,67 @@ static int bson_append_string_uppercase( bson *b, const char *name, const char *
 }
 
 static int gridfs_insert_file(gridfs *gfs, const char *name, const bson_oid_t id, gridfs_offset length, const char *contenttype, int flags, int chunkSize) {
-  bson command = INIT_BSON;
-  bson ret = INIT_BSON;
-  bson res = INIT_BSON;
-  bson_iterator it = INIT_ITERATOR;
-  bson q = INIT_BSON;
+  bson command[1];
+  bson ret[1];
+  bson res[1];
+  bson_iterator it[1];
+  bson q[1];
   int result;
   int64_t d;
 
   /* If you don't care about calculating MD5 hash for a particular file, simply pass the GRIDFILE_NOMD5 value on the flag param */
   if( !( flags & GRIDFILE_NOMD5 ) ) {  
     /* Check run md5 */
-    bson_init(&command);
-    bson_append_oid(&command, "filemd5", &id);
-    bson_append_string(&command, "root", gfs->prefix);
-    bson_finish(&command);
-    result = mongo_run_command(gfs->client, gfs->dbname, &command, &res);
-    bson_destroy(&command);
-    if (result != MONGO_OK) {
+    bson_init(command);
+    bson_append_oid(command, "filemd5", &id);
+    bson_append_string(command, "root", gfs->prefix);
+    bson_finish(command);
+    result = mongo_run_command(gfs->client, gfs->dbname, command, res);
+    bson_destroy(command);
+    if (result != MONGO_OK) 
       return result;
-    } 
   } 
 
   /* Create and insert BSON for file metadata */
-  bson_init(&ret);
-  bson_append_oid(&ret, "_id", &id);
+  bson_init(ret);
+  bson_append_oid(ret, "_id", &id);
   if (name != NULL &&  *name != '\0') {
-    bson_append_string_uppercase( &ret, "filename", name, gfs->caseInsensitive );
+    bson_append_string_uppercase( ret, "filename", name, gfs->caseInsensitive );
   }
-  bson_append_long(&ret, "length", length);
-  bson_append_int(&ret, "chunkSize", chunkSize);
+  bson_append_long(ret, "length", length);
+  bson_append_int(ret, "chunkSize", chunkSize);
   d = (bson_date_t)1000 * time(NULL);
-  bson_append_date(&ret, "uploadDate", d);
+  bson_append_date(ret, "uploadDate", d);
   if( !( flags & GRIDFILE_NOMD5 ) ) {
-    bson_find(&it, &res, "md5");
-    bson_append_string(&ret, "md5", bson_iterator_string(&it));
-    bson_destroy(&res);
+    bson_find(it, res, "md5");
+    bson_append_string(ret, "md5", bson_iterator_string(it));
+    bson_destroy(res);
   } else {
-    bson_append_string(&ret, "md5", ""); 
+    bson_append_string(ret, "md5", ""); 
   } 
   if (contenttype != NULL &&  *contenttype != '\0') {
-    bson_append_string(&ret, "contentType", contenttype);
+    bson_append_string(ret, "contentType", contenttype);
   }
   if ( gfs->caseInsensitive ) {
-    bson_append_string(&ret, "realFilename", name);
+    bson_append_string(ret, "realFilename", name);
   }
-  bson_append_int(&ret, "flags", flags);
-  bson_finish(&ret);
+  bson_append_int(ret, "flags", flags);
+  bson_finish(ret);
 
-  bson_init(&q);
-  bson_append_oid(&q, "_id", &id);
-  bson_finish(&q);
+  bson_init(q);
+  bson_append_oid(q, "_id", &id);
+  bson_finish(q);
 
-  result = mongo_update(gfs->client, gfs->files_ns, &q, &ret, MONGO_UPDATE_UPSERT, NULL);
+  result = mongo_update(gfs->client, gfs->files_ns, q, ret, MONGO_UPDATE_UPSERT, NULL);
 
-  bson_destroy(&ret);
-  bson_destroy(&q);
+  bson_destroy(ret);
+  bson_destroy(q);
   
   return result;
 }
 
 MONGO_EXPORT int gridfs_store_buffer(gridfs *gfs, const char *data, gridfs_offset length, const char *remotename, const char *contenttype, int flags ) {
-  gridfile gfile = INIT_GRIDFILE;
+  gridfile gfile;
   gridfs_offset bytes_written;
   
   gridfile_init( gfs, NULL, &gfile );
@@ -311,7 +310,7 @@ MONGO_EXPORT int gridfs_store_file(gridfs *gfs, const char *filename, const char
   char buffer[DEFAULT_CHUNK_SIZE];
   FILE *fd;    
   gridfs_offset chunkLen;
-  gridfile gfile = INIT_GRIDFILE;
+  gridfile gfile;
   gridfs_offset bytes_written = 0;
 
   /* Open the file and the correct stream */
@@ -353,42 +352,42 @@ MONGO_EXPORT int gridfs_store_file(gridfs *gfs, const char *filename, const char
 }
 
 MONGO_EXPORT int gridfs_remove_filename(gridfs *gfs, const char *filename) {
-  bson query = INIT_BSON;
+  bson query[1];
   mongo_cursor *files;
-  bson file = INIT_BSON;
-  bson_iterator it = INIT_ITERATOR;
+  bson file[1];
+  bson_iterator it[1];
   bson_oid_t id;
-  bson b = INIT_BSON;
+  bson b[1];
   int ret = MONGO_ERROR;
 
-  bson_init(&query);
-  bson_append_string_uppercase( &query, "filename", filename, gfs->caseInsensitive );
-  bson_finish(&query);
-  files = mongo_find(gfs->client, gfs->files_ns, &query, NULL, 0, 0, 0);
-  bson_destroy(&query);
+  bson_init(query);
+  bson_append_string_uppercase( query, "filename", filename, gfs->caseInsensitive );
+  bson_finish(query);
+  files = mongo_find(gfs->client, gfs->files_ns, query, NULL, 0, 0, 0);
+  bson_destroy(query);
 
   /* files should be a valid cursor even if the file doesn't exist */
   if ( files == NULL ) return MONGO_ERROR; 
 
   /* Remove each file and it's chunks from files named filename */
   while (mongo_cursor_next(files) == MONGO_OK) {
-    file = files->current;
-    bson_find(&it, &file, "_id");
-    id =  *bson_iterator_oid(&it);
+    *file = files->current;
+    bson_find(it, file, "_id");
+    id =  *bson_iterator_oid(it);
 
     /* Remove the file with the specified id */
-    bson_init(&b);
-    bson_append_oid(&b, "_id", &id);
-    bson_finish(&b);
-    mongo_remove(gfs->client, gfs->files_ns, &b, NULL);
-    bson_destroy(&b);
+    bson_init(b);
+    bson_append_oid(b, "_id", &id);
+    bson_finish(b);
+    mongo_remove(gfs->client, gfs->files_ns, b, NULL);
+    bson_destroy(b);
 
     /* Remove all chunks from the file with the specified id */
-    bson_init(&b);
-    bson_append_oid(&b, "files_id", &id);
-    bson_finish(&b);
-    ret = mongo_remove(gfs->client, gfs->chunks_ns, &b, NULL);
-    bson_destroy(&b);
+    bson_init(b);
+    bson_append_oid(b, "files_id", &id);
+    bson_finish(b);
+    ret = mongo_remove(gfs->client, gfs->chunks_ns, b, NULL);
+    bson_destroy(b);
   }
 
   mongo_cursor_destroy(files);
@@ -397,41 +396,41 @@ MONGO_EXPORT int gridfs_remove_filename(gridfs *gfs, const char *filename) {
 
 MONGO_EXPORT int gridfs_find_query( gridfs *gfs, const bson *query, gridfile *gfile ) {
 
-  bson uploadDate = INIT_BSON;
-  bson finalQuery = INIT_BSON;
-  bson out = INIT_BSON;
+  bson uploadDate[1];
+  bson finalQuery[1];
+  bson out[1];
   int i;
 
-  bson_init(&uploadDate);
-  bson_append_int(&uploadDate, "uploadDate",  - 1);
-  bson_finish(&uploadDate);
+  bson_init(uploadDate);
+  bson_append_int(uploadDate, "uploadDate",  - 1);
+  bson_finish(uploadDate);
 
-  bson_init(&finalQuery);
-  bson_append_bson(&finalQuery, "query", query);
-  bson_append_bson(&finalQuery, "orderby", &uploadDate);
-  bson_finish(&finalQuery);
+  bson_init(finalQuery);
+  bson_append_bson(finalQuery, "query", query);
+  bson_append_bson(finalQuery, "orderby", uploadDate);
+  bson_finish(finalQuery);
 
-  i = (mongo_find_one(gfs->client, gfs->files_ns,  &finalQuery, NULL, &out) == MONGO_OK);
-  bson_destroy(&uploadDate);
-  bson_destroy(&finalQuery);
+  i = (mongo_find_one(gfs->client, gfs->files_ns,  finalQuery, NULL, out) == MONGO_OK);
+  bson_destroy(uploadDate);
+  bson_destroy(finalQuery);
   if (!i) {
     return MONGO_ERROR;
   } else {
-    gridfile_init(gfs, &out, gfile);
-    bson_destroy(&out);
+    gridfile_init(gfs, out, gfile);
+    bson_destroy(out);
     return MONGO_OK;
   }
 }
 
 MONGO_EXPORT int gridfs_find_filename(gridfs *gfs, const char *filename, gridfile *gfile){
-  bson query = INIT_BSON;
+  bson query[1];
   int res;
 
-  bson_init(&query);
-  bson_append_string_uppercase( &query, "filename", filename, gfs->caseInsensitive );
-  bson_finish(&query);
-  res = gridfs_find_query(gfs, &query, gfile);
-  bson_destroy(&query);
+  bson_init(query);
+  bson_append_string_uppercase( query, "filename", filename, gfs->caseInsensitive );
+  bson_finish(query);
+  res = gridfs_find_query(gfs, query, gfile);
+  bson_destroy(query);
   return res;
 }
 
@@ -495,45 +494,40 @@ MONGO_EXPORT int gridfile_writer_done(gridfile *gfile) {
 }
 
 static void gridfile_init_chunkSize(gridfile *gfile){
-  bson_iterator it = INIT_ITERATOR;
+    bson_iterator it[1];
 
-  if( bson_find(&it, gfile->meta, "chunkSize") != BSON_EOO ) {
-    if (bson_iterator_type(&it) == BSON_INT) {
-      gfile->chunkSize = bson_iterator_int(&it);
-    } else {
-      gfile->chunkSize = (int)bson_iterator_long(&it);
-    }
-  } else {
-    gfile->chunkSize = DEFAULT_CHUNK_SIZE;
-  }
+    if (bson_find(it, gfile->meta, "chunkSize") != BSON_EOO)
+        if (bson_iterator_type(it) == BSON_INT)
+            gfile->chunkSize = bson_iterator_int(it);
+        else
+            gfile->chunkSize = (int)bson_iterator_long(it);
+    else
+        gfile->chunkSize = DEFAULT_CHUNK_SIZE;
 }
 
 static void gridfile_init_length(gridfile *gfile) {
-  bson_iterator it = INIT_ITERATOR;
+    bson_iterator it[1];
 
-  if( bson_find(&it, gfile->meta, "length") != BSON_EOO ) {
-    if (bson_iterator_type(&it) == BSON_INT) {
-      gfile->length = (gridfs_offset)bson_iterator_int(&it);
-    } else {
-      gfile->length = (gridfs_offset)bson_iterator_long(&it);
-    }
-  } else {
-    gfile->length = 0;
-  }
+    if (bson_find(it, gfile->meta, "length") != BSON_EOO)
+        if (bson_iterator_type(it) == BSON_INT)
+            gfile->length = (gridfs_offset)bson_iterator_int(it);
+        else
+            gfile->length = (gridfs_offset)bson_iterator_long(it);
+    else
+        gfile->length = 0;
 }
 
 static void gridfile_init_flags(gridfile *gfile) {
-  bson_iterator it = INIT_ITERATOR;
+  bson_iterator it[1];
 
-  if( bson_find(&it, gfile->meta, "flags") != BSON_EOO ) {
-    gfile->flags = bson_iterator_int(&it);
-  } else {
+  if( bson_find(it, gfile->meta, "flags") != BSON_EOO )
+    gfile->flags = bson_iterator_int(it);
+  else
     gfile->flags = 0;
-  }
 }
 
 MONGO_EXPORT int gridfile_writer_init(gridfile *gfile, gridfs *gfs, const char *remote_name, const char *content_type, int flags ) {
-  gridfile tmpFile = INIT_GRIDFILE;
+  gridfile tmpFile;
 
   gfile->gfs = gfs;
   if (gridfs_find_filename(gfs, remote_name, &tmpFile) == MONGO_OK) {
@@ -590,17 +584,15 @@ MONGO_EXPORT void gridfile_destroy(gridfile *gfile) {
 /* gridfile accessors */
 
 MONGO_EXPORT bson_oid_t gridfile_get_id( const gridfile *gfile ) {
-  bson_iterator it = INIT_ITERATOR;
+  bson_iterator it[1];
 
-  if( bson_find(&it, gfile->meta, "_id") != BSON_EOO) {
-    if (bson_iterator_type(&it) == BSON_OID) {
-      return *bson_iterator_oid(&it);
-    } else {
-      return gfile->id;
-    } 
-  } else {
-    return gfile->id;
-  }
+    if (bson_find(it, gfile->meta, "_id") != BSON_EOO)
+        if (bson_iterator_type(it) == BSON_OID)
+            return *bson_iterator_oid(it);
+        else
+            return gfile->id;
+    else
+        return gfile->id;
 }
 
 MONGO_EXPORT bson_bool_t gridfile_exists( const gridfile *gfile ) {
@@ -609,30 +601,25 @@ MONGO_EXPORT bson_bool_t gridfile_exists( const gridfile *gfile ) {
 }
 
 MONGO_EXPORT const char *gridfile_get_filename( const gridfile *gfile ) {
-  bson_iterator it = INIT_ITERATOR;
+    bson_iterator it[1];
 
-  if( gfile->gfs->caseInsensitive && bson_find( &it, gfile->meta, "realFilename" ) != BSON_EOO ) {
-    return bson_iterator_string(&it); 
-  }
-  if( bson_find(&it, gfile->meta, "filename") != BSON_EOO) {
-    return bson_iterator_string(&it);
-  } else {
-    return gfile->remote_name;
-  }
+    if (gfile->gfs->caseInsensitive && bson_find( it, gfile->meta, "realFilename" ) != BSON_EOO)
+        return bson_iterator_string(it); 
+    if (bson_find(it, gfile->meta, "filename") != BSON_EOO)
+        return bson_iterator_string(it);
+    else
+        return gfile->remote_name;
 }
 
 MONGO_EXPORT int gridfile_get_chunksize( const gridfile *gfile ) {
-  bson_iterator it = INIT_ITERATOR;
+    bson_iterator it[1];
 
-  if( gfile->chunkSize ) {
-    return gfile->chunkSize;
-  } else {
-    if( bson_find(&it, gfile->meta, "chunkSize") != BSON_EOO ) {
-      return bson_iterator_int(&it);
-  } else {  
-      return DEFAULT_CHUNK_SIZE;
-    }
-  }
+    if (gfile->chunkSize)
+        return gfile->chunkSize;
+    else if (bson_find(it, gfile->meta, "chunkSize") != BSON_EOO)
+        return bson_iterator_int(it);
+    else
+        return DEFAULT_CHUNK_SIZE;
 }
 
 MONGO_EXPORT gridfs_offset gridfile_get_contentlength( const gridfile *gfile ) {
@@ -642,37 +629,34 @@ MONGO_EXPORT gridfs_offset gridfile_get_contentlength( const gridfile *gfile ) {
 }
 
 MONGO_EXPORT const char *gridfile_get_contenttype( const gridfile *gfile ) {
-  bson_iterator it = INIT_ITERATOR;
+    bson_iterator it[1];
 
-  if ( bson_find(&it, gfile->meta, "contentType") != BSON_EOO ) {
-    return bson_iterator_string(&it);
-  } else {
-    return NULL;
-  } 
+    if ( bson_find(it, gfile->meta, "contentType") != BSON_EOO )
+        return bson_iterator_string(it);
+    else
+        return NULL;
 }
 
 MONGO_EXPORT bson_date_t gridfile_get_uploaddate( const gridfile *gfile ) {
-  bson_iterator it = INIT_ITERATOR;
+    bson_iterator it[1];
 
-  if( bson_find(&it, gfile->meta, "uploadDate") != BSON_EOO) {
-    return bson_iterator_date(&it);
-  } else {
-    return 0;
-  }
+    if (bson_find(it, gfile->meta, "uploadDate") != BSON_EOO)
+        return bson_iterator_date(it);
+    else
+        return 0;
 }
 
 MONGO_EXPORT const char *gridfile_get_md5( const gridfile *gfile ) {
-  bson_iterator it = INIT_ITERATOR;
+    bson_iterator it[1];
 
-  if( bson_find(&it, gfile->meta, "md5") != BSON_EOO ) {
-    return bson_iterator_string(&it);
-  } else {
-    return NULL;
-  }
+    if (bson_find(it, gfile->meta, "md5") != BSON_EOO )
+        return bson_iterator_string(it);
+    else
+        return NULL;
 }
 
-MONGO_EXPORT void gridfile_set_flags(gridfile *gfile, int flags){
-  gfile->flags = flags;
+MONGO_EXPORT void gridfile_set_flags(gridfile *gfile, int flags) {
+    gfile->flags = flags;
 }
 
 MONGO_EXPORT int gridfile_get_flags( const gridfile *gfile ) {
@@ -680,33 +664,30 @@ MONGO_EXPORT int gridfile_get_flags( const gridfile *gfile ) {
 }
 
 MONGO_EXPORT const char *gridfile_get_field(gridfile *gfile, const char *name) {
-  bson_iterator it = INIT_ITERATOR;
+    bson_iterator it[1];
 
-  if( bson_find(&it, gfile->meta, name) != BSON_EOO) {
-    return bson_iterator_value(&it);
-  } else {
-    return NULL;
-  }
+    if (bson_find(it, gfile->meta, name) != BSON_EOO)
+        return bson_iterator_value(it);
+    else
+        return NULL;
 }
 
 MONGO_EXPORT bson_bool_t gridfile_get_boolean( const gridfile *gfile, const char *name ) {
-  bson_iterator it = INIT_ITERATOR;
+    bson_iterator it[1];
 
-  if( bson_find(&it, gfile->meta, name) != BSON_EOO) {
-    return bson_iterator_bool(&it);
-  } else {
-    return 0;
-  }
+    if (bson_find(it, gfile->meta, name) != BSON_EOO)
+        return bson_iterator_bool(it);
+    else
+        return 0;
 }
 
 MONGO_EXPORT void gridfile_get_metadata( const gridfile *gfile, bson *out, bson_bool_t copyData ) {
-  bson_iterator it = INIT_ITERATOR;
+    bson_iterator it[1];
 
-  if( bson_find(&it, gfile->meta, "metadata") != BSON_EOO ) {
-    bson_iterator_subobject_init(&it, out, copyData);
-  } else {
-    bson_init_empty(out);
-  } 
+    if (bson_find(it, gfile->meta, "metadata") != BSON_EOO)
+        bson_iterator_subobject_init(it, out, copyData);
+    else
+        bson_init_empty(out);
 }
 
 /* ++++++++++++++++++++++++++++++++ */
@@ -714,23 +695,22 @@ MONGO_EXPORT void gridfile_get_metadata( const gridfile *gfile, bson *out, bson_
 /* ++++++++++++++++++++++++++++++++ */
 
 MONGO_EXPORT int gridfile_get_numchunks( const gridfile *gfile ) {
-  bson_iterator it = INIT_ITERATOR;
-  gridfs_offset length;
-  gridfs_offset chunkSize;
-  double numchunks;
+    bson_iterator it[1];
+    gridfs_offset length;
+    gridfs_offset chunkSize;
+    double numchunks;
 
-  bson_find(&it, gfile->meta, "length");
+    bson_find(it, gfile->meta, "length");
 
-  if ( bson_iterator_type(&it) == BSON_INT ) {
-    length = (gridfs_offset)bson_iterator_int(&it);
-  } else {
-    length = (gridfs_offset)bson_iterator_long(&it);
-  } 
+    if (bson_iterator_type(it) == BSON_INT)
+        length = (gridfs_offset)bson_iterator_int(it);
+    else
+        length = (gridfs_offset)bson_iterator_long(it);
  
-  bson_find(&it, gfile->meta, "chunkSize");
-  chunkSize = bson_iterator_int(&it);
-  numchunks = ((double)length / (double)chunkSize);
-  return (numchunks - (int)numchunks > 0) ? (int)(numchunks + 1): (int)(numchunks);
+    bson_find(it, gfile->meta, "chunkSize");
+    chunkSize = bson_iterator_int(it);
+    numchunks = ((double)length / (double)chunkSize);
+    return (numchunks - (int)numchunks > 0) ? (int)(numchunks + 1): (int)(numchunks);
 }
 
 static void gridfile_prepare_chunk_key_bson(bson *q, bson_oid_t *id, int chunk_num) {
@@ -741,52 +721,50 @@ static void gridfile_prepare_chunk_key_bson(bson *q, bson_oid_t *id, int chunk_n
 }
 
 static int gridfile_flush_pendingchunk(gridfile *gfile) {
-  bson *oChunk;
-  bson q = INIT_BSON;
-  char* targetBuf = NULL;
-  int res = MONGO_OK;
+    bson *oChunk;
+    bson q[1];
+    char* targetBuf = NULL;
+    int res = MONGO_OK;
 
-  if (gfile->pending_len) {
-    size_t finish_position_after_flush;
-    oChunk = chunk_new( gfile->id, gfile->chunk_num, &targetBuf, gfile->pending_data, gfile->pending_len, gfile->flags );
-    gridfile_prepare_chunk_key_bson( &q, &gfile->id, gfile->chunk_num );    
-    res = mongo_update(gfile->gfs->client, gfile->gfs->chunks_ns, &q, oChunk, MONGO_UPDATE_UPSERT, NULL);
-    bson_destroy(&q);
-    chunk_free(oChunk);    
-    if( res == MONGO_OK ){      
-      finish_position_after_flush = (gfile->chunk_num * gfile->chunkSize) + gfile->pending_len;
-      if(finish_position_after_flush > gfile->length) {
-        gfile->length = finish_position_after_flush;
-      }
-      gfile->chunk_num++;
-      gfile->pending_len = 0;
+    if (gfile->pending_len) {
+        size_t finish_position_after_flush;
+        oChunk = chunk_new( gfile->id, gfile->chunk_num, &targetBuf, gfile->pending_data, gfile->pending_len, gfile->flags );
+        gridfile_prepare_chunk_key_bson( q, &gfile->id, gfile->chunk_num );    
+        res = mongo_update(gfile->gfs->client, gfile->gfs->chunks_ns, q, oChunk, MONGO_UPDATE_UPSERT, NULL);
+        bson_destroy(q);
+        chunk_free(oChunk);    
+        if( res == MONGO_OK ){      
+            finish_position_after_flush = (gfile->chunk_num * gfile->chunkSize) + gfile->pending_len;
+            if (finish_position_after_flush > gfile->length)
+                gfile->length = finish_position_after_flush;
+            gfile->chunk_num++;
+            gfile->pending_len = 0;
+        }
     }
-  }
-  if( targetBuf && targetBuf != gfile->pending_data ) {
-    bson_free( targetBuf );
-  }
-  return res;
+    if (targetBuf && targetBuf != gfile->pending_data)
+        bson_free( targetBuf );
+    return res;
 }
 
 static int gridfile_load_pending_data_with_pos_chunk(gridfile *gfile) {
   int chunk_len;
   const char *chunk_data;
-  bson_iterator it = INIT_ITERATOR;
-  bson chk = INIT_BSON;
+  bson_iterator it[1];
+  bson chk;
   char* targetBuffer = NULL;
   size_t targetBufferLen = 0;
 
   chk.dataSize = 0;
   gridfile_get_chunk(gfile, (int)(gfile->pos / DEFAULT_CHUNK_SIZE), &chk);
   if (chk.dataSize <= 5) {
-    if( chk.data ) {
-      bson_destroy( &chk );
-    }
-    return MONGO_ERROR;
+        if( chk.data ) {
+            bson_destroy( &chk );
+        }
+        return MONGO_ERROR;
   }
-  if( bson_find(&it, &chk, "data") != BSON_EOO){
-    chunk_len = bson_iterator_bin_len(&it);
-    chunk_data = bson_iterator_bin_data(&it);
+  if( bson_find(it, &chk, "data") != BSON_EOO){
+    chunk_len = bson_iterator_bin_len(it);
+    chunk_data = bson_iterator_bin_data(it);
     gridfs_read_filter( &targetBuffer, &targetBufferLen, chunk_data, (size_t)chunk_len, gfile->flags );
     gfile->pending_len = (int)targetBufferLen;
     gfile->chunk_num = (int)(gfile->pos / DEFAULT_CHUNK_SIZE);
@@ -798,16 +776,15 @@ static int gridfile_load_pending_data_with_pos_chunk(gridfile *gfile) {
     return MONGO_ERROR;
   }
   bson_destroy( &chk );
-  if( targetBuffer && targetBuffer != chunk_data ) {
+  if( targetBuffer && targetBuffer != chunk_data )
     bson_free( targetBuffer );
-  }
   return MONGO_OK;
 }
 
 MONGO_EXPORT gridfs_offset gridfile_write_buffer(gridfile *gfile, const char *data, gridfs_offset length) {
 
   bson *oChunk;
-  bson q = INIT_BSON;
+  bson q[1];
   size_t buf_pos, buf_bytes_to_write;    
   gridfs_offset bytes_left = length;
   char* targetBuf = NULL;
@@ -837,9 +814,9 @@ MONGO_EXPORT gridfs_offset gridfile_write_buffer(gridfile *gfile, const char *da
     int res; 
     if( (oChunk = chunk_new( gfile->id, gfile->chunk_num, &targetBuf, data, DEFAULT_CHUNK_SIZE, gfile->flags )) == NULL) return length - bytes_left;
     memAllocated = targetBuf != data;
-    gridfile_prepare_chunk_key_bson( &q, &gfile->id, gfile->chunk_num);
-    res = mongo_update(gfile->gfs->client, gfile->gfs->chunks_ns, &q, oChunk, MONGO_UPDATE_UPSERT, NULL);
-    bson_destroy( &q );
+    gridfile_prepare_chunk_key_bson(q, &gfile->id, gfile->chunk_num);
+    res = mongo_update(gfile->gfs->client, gfile->gfs->chunks_ns, q, oChunk, MONGO_UPDATE_UPSERT, NULL);
+    bson_destroy(q );
     chunk_free(oChunk);
     if( res != MONGO_OK ) return length - bytes_left;
     bytes_left -= DEFAULT_CHUNK_SIZE;
@@ -860,9 +837,8 @@ MONGO_EXPORT gridfs_offset gridfile_write_buffer(gridfile *gfile, const char *da
     if( !gfile->pending_len && gfile->pos + bytes_left < gfile->length && gridfile_load_pending_data_with_pos_chunk( gfile ) != MONGO_OK ) 
       return length - bytes_left;
     memcpy( gfile->pending_data, data, (size_t) bytes_left );
-    if(  bytes_left > gfile->pending_len ) {
+    if(  bytes_left > gfile->pending_len )
       gfile->pending_len = (int) bytes_left;
-    }
     gfile->pos += bytes_left;  
   }
 
@@ -873,68 +849,64 @@ MONGO_EXPORT gridfs_offset gridfile_write_buffer(gridfile *gfile, const char *da
 }
 
 MONGO_EXPORT void gridfile_get_chunk(gridfile *gfile, int n, bson *out) {
-  bson query = INIT_BSON;
+  bson query[1];
 
   bson_oid_t id;
   int result;
 
-  bson_init(&query);  
+  bson_init(query);  
   id = gridfile_get_id( gfile );
-  bson_append_oid(&query, "files_id", &id);
-  bson_append_int(&query, "n", n);
-  bson_finish(&query);
+  bson_append_oid(query, "files_id", &id);
+  bson_append_int(query, "n", n);
+  bson_finish(query);
 
-  result = (mongo_find_one(gfile->gfs->client, gfile->gfs->chunks_ns, &query, NULL, out) == MONGO_OK);
-  bson_destroy(&query);
-  if (!result) {
-    bson empty = INIT_BSON;
-    bson_init_empty(&empty);
-    bson_copy(out, &empty);
-  }
+  result = (mongo_find_one(gfile->gfs->client, gfile->gfs->chunks_ns, query, NULL, out) == MONGO_OK);
+  bson_destroy(query);
+  if (!result)
+    bson_copy(out, bson_shared_empty());
 }
 
 MONGO_EXPORT mongo_cursor *gridfile_get_chunks(gridfile *gfile, size_t start, size_t size) {
-  bson_iterator it = INIT_ITERATOR;
+  bson_iterator it[1];
   bson_oid_t id;
-  bson gte = INIT_BSON;
-  bson query = INIT_BSON;
-  bson orderby = INIT_BSON;
-  bson command = INIT_BSON;
+  bson gte[1];
+  bson query[1];
+  bson orderby[1];
+  bson command[1];
   mongo_cursor *cursor;
 
-  if( bson_find(&it, gfile->meta, "_id") != BSON_EOO) {
-    id =  *bson_iterator_oid(&it);
-  } else {
+  if( bson_find(it, gfile->meta, "_id") != BSON_EOO)
+    id =  *bson_iterator_oid(it);
+  else
     id = gfile->id;
-  }
 
-  bson_init(&query);
-  bson_append_oid(&query, "files_id", &id);
+  bson_init(query);
+  bson_append_oid(query, "files_id", &id);
   if (size == 1) {
-    bson_append_int(&query, "n", (int)start);
+    bson_append_int(query, "n", (int)start);
   } else {
-    bson_init(&gte);
-    bson_append_int(&gte, "$gte", (int)start);
-    bson_finish(&gte);
-    bson_append_bson(&query, "n", &gte);
-    bson_destroy(&gte);
+    bson_init(gte);
+    bson_append_int(gte, "$gte", (int)start);
+    bson_finish(gte);
+    bson_append_bson(query, "n", gte);
+    bson_destroy(gte);
   }
-  bson_finish(&query);
+  bson_finish(query);
 
-  bson_init(&orderby);
-  bson_append_int(&orderby, "n", 1);
-  bson_finish(&orderby);
+  bson_init(orderby);
+  bson_append_int(orderby, "n", 1);
+  bson_finish(orderby);
 
-  bson_init(&command);
-  bson_append_bson(&command, "query", &query);
-  bson_append_bson(&command, "orderby", &orderby);
-  bson_finish(&command);
+  bson_init(command);
+  bson_append_bson(command, "query", query);
+  bson_append_bson(command, "orderby", orderby);
+  bson_finish(command);
 
-  cursor = mongo_find(gfile->gfs->client, gfile->gfs->chunks_ns,  &command, NULL, (int)size, 0, 0);
+  cursor = mongo_find(gfile->gfs->client, gfile->gfs->chunks_ns,  command, NULL, (int)size, 0, 0);
 
-  bson_destroy(&command);
-  bson_destroy(&query);
-  bson_destroy(&orderby);
+  bson_destroy(command);
+  bson_destroy(query);
+  bson_destroy(orderby);
 
   return cursor;
 }
@@ -1023,13 +995,13 @@ static gridfs_offset gridfile_load_from_chunks(gridfile *gfile, int total_chunks
 
 static gridfs_offset gridfile_fill_buf_from_chunk(gridfile *gfile, const bson *chunk, gridfs_offset chunksize, char **buf, int *allocatedMem, char **targetBuf, 
                                                   size_t *targetBufLen, gridfs_offset *bytes_left, int chunkNo){
-  bson_iterator it = INIT_ITERATOR;
+  bson_iterator it[1];
   gridfs_offset chunk_len;
   const char *chunk_data;
 
-  if( bson_find(&it, chunk, "data") != BSON_EOO ) {
-    chunk_len = bson_iterator_bin_len(&it);
-    chunk_data = bson_iterator_bin_data(&it);  
+  if( bson_find(it, chunk, "data") != BSON_EOO ) {
+    chunk_len = bson_iterator_bin_len(it);
+    chunk_data = bson_iterator_bin_data(it);  
     if( gridfs_read_filter( targetBuf, targetBufLen, chunk_data, (size_t)chunk_len, gfile->flags ) != 0) return 0;
     *allocatedMem = *targetBuf != chunk_data;
     chunk_data = *targetBuf;
@@ -1085,20 +1057,20 @@ MONGO_EXPORT gridfs_offset gridfile_write_file(gridfile *gfile, FILE *stream) {
 }
 
 static int gridfile_remove_chunks( gridfile *gfile, int deleteFromChunk){
-  bson q = INIT_BSON;
+  bson q[1];
   bson_oid_t id = gridfile_get_id( gfile );
   int res;
 
-  bson_init( &q );
-  bson_append_oid(&q, "files_id", &id);
+  bson_init( q );
+  bson_append_oid(q, "files_id", &id);
   if( deleteFromChunk >= 0 ) {
-    bson_append_start_object( &q, "n" );
-    bson_append_int( &q, "$gte", deleteFromChunk );
-    bson_append_finish_object( &q );
+    bson_append_start_object( q, "n" );
+    bson_append_int( q, "$gte", deleteFromChunk );
+    bson_append_finish_object( q );
   }
-  bson_finish( &q );
-  res = mongo_remove( gfile->gfs->client, gfile->gfs->chunks_ns, &q, NULL);
-  bson_destroy( &q );
+  bson_finish( q );
+  res = mongo_remove( gfile->gfs->client, gfile->gfs->chunks_ns, q, NULL);
+  bson_destroy( q );
   return res;
 }
 

--- a/src/gridfs.h
+++ b/src/gridfs.h
@@ -59,8 +59,6 @@ enum gridfile_storage_type {
     GRIDFILE_NOMD5 = ( 1<<0 )
 };
 
-#define INIT_GRIDFILE  {NULL}
-
 #ifndef _MSC_VER
 char *_strupr(char *str);
 char *_strlwr(char *str);

--- a/src/mongo.c
+++ b/src/mongo.c
@@ -126,25 +126,23 @@ MONGO_EXPORT const char*  mongo_get_server_err_string(mongo* conn) {
 
 MONGO_EXPORT void __mongo_set_error( mongo *conn, mongo_error_t err, const char *str,
                                      int errcode ) {
-    size_t errstr_size, str_size;
-
+    size_t str_size = 1;
     conn->err = err;
     conn->errcode = errcode;
-
     if( str ) {
         str_size = strlen( str ) + 1;
-        errstr_size = str_size > MONGO_ERR_LEN ? MONGO_ERR_LEN : str_size;
-        memcpy( conn->errstr, str, errstr_size );
-        conn->errstr[errstr_size-1] = '\0';
+        if (str_size > MONGO_ERR_LEN) str_size = MONGO_ERR_LEN;
+        memcpy( conn->errstr, str, str_size );
     }
+    conn->errstr[str_size-1] = '\0';
 }
 
 MONGO_EXPORT void mongo_clear_errors( mongo *conn ) {
-    conn->err = 0;
+    conn->err = MONGO_CONN_SUCCESS;
     conn->errcode = 0;
     conn->lasterrcode = 0;
-    memset( conn->errstr, 0, MONGO_ERR_LEN );
-    memset( conn->lasterrstr, 0, MONGO_ERR_LEN );
+    conn->errstr[0] = 0;
+    conn->lasterrstr[0] = 0;
 }
 
 /* Note: this function returns a char* which must be freed. */
@@ -268,13 +266,14 @@ MONGO_EXPORT int mongo_validate_ns( mongo *conn, const char *ns ) {
 }
 
 static void mongo_set_last_error( mongo *conn, bson_iterator *it, bson *obj ) {
+    bson_iterator iter[1];
     int result_len = bson_iterator_string_len( it );
     const char *result_string = bson_iterator_string( it );
     int len = result_len < MONGO_ERR_LEN ? result_len : MONGO_ERR_LEN;
     memcpy( conn->lasterrstr, result_string, len );
-
-    if( bson_find( it, obj, "code" ) != BSON_NULL )
-        conn->lasterrcode = bson_iterator_int( it );
+    iter[0] = *it;  // no side effects on the passed iter
+    if( bson_find( iter, obj, "code" ) != BSON_NULL )
+        conn->lasterrcode = bson_iterator_int( iter );
 }
 
 static const int ZERO = 0;
@@ -394,8 +393,6 @@ static int mongo_check_is_master( mongo *conn ) {
     bson_bool_t ismaster = 0;
     int max_bson_size = MONGO_DEFAULT_MAX_BSON_SIZE;
 
-    out.data = NULL;
-
     if ( mongo_simple_int_command( conn, "admin", "ismaster", 1, &out ) != MONGO_OK )
         return MONGO_ERROR;
 
@@ -422,7 +419,7 @@ MONGO_EXPORT void mongo_init_sockets( void ) {
 /* WC1 is completely static */
 static char WC1_data[] = {23,0,0,0,16,103,101,116,108,97,115,116,101,114,114,111,114,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0};
 static bson WC1_cmd = {
-    WC1_data, WC1_data, 128, 1, 0, {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}, 0, 0, 0, 0
+    WC1_data, WC1_data, 128, 1, 0
 };
 static mongo_write_concern WC1 = { 1, 0, 0, 0, 0, &WC1_cmd }; /* w = 1 */
 
@@ -538,24 +535,23 @@ void mongo_parse_host( const char *host_string, mongo_host_port *host_port ) {
 }
 
 static void mongo_replica_set_check_seed( mongo *conn ) {
-    bson out;
+    bson out[1];
     const char *data;
-    bson_iterator it;
-    bson_iterator it_sub;
+    bson_iterator it[1];
+    bson_iterator it_sub[1];
     const char *host_string;
     mongo_host_port *host_port = NULL;
 
-    out.data = NULL;
-    if( mongo_simple_int_command( conn, "admin", "ismaster", 1, &out ) == MONGO_OK ) {
+    if( mongo_simple_int_command( conn, "admin", "ismaster", 1, out ) == MONGO_OK ) {
 
-        if( bson_find( &it, &out, "hosts" ) ) {
-            data = bson_iterator_value( &it );
-            bson_iterator_from_buffer( &it_sub, data );
+        if( bson_find( it, out, "hosts" ) ) {
+            data = bson_iterator_value( it );
+            bson_iterator_from_buffer( it_sub, data );
 
             /* Iterate over host list, adding each host to the
              * connection's host list. */
-            while( bson_iterator_next( &it_sub ) ) {
-                host_string = bson_iterator_string( &it_sub );
+            while( bson_iterator_next( it_sub ) ) {
+                host_string = bson_iterator_string( it_sub );
 
                 host_port = (mongo_host_port*)bson_malloc( sizeof( mongo_host_port ) );
 
@@ -571,11 +567,10 @@ static void mongo_replica_set_check_seed( mongo *conn ) {
         }
     }
 
-    bson_destroy( &out );
+    bson_destroy(out);
     mongo_env_close_socket( conn->sock );
     conn->sock = 0;
     conn->connected = 0;
-
 }
 
 /* Find out whether the current connected node is master, and
@@ -583,33 +578,31 @@ static void mongo_replica_set_check_seed( mongo *conn ) {
  */
 static int mongo_replica_set_check_host( mongo *conn ) {
 
-    bson out;
-    bson_iterator it;
+    bson out[1];
+    bson_iterator it[1];
     bson_bool_t ismaster = 0;
     const char *set_name;
     int max_bson_size = MONGO_DEFAULT_MAX_BSON_SIZE;
 
-    out.data = NULL;
+    if ( mongo_simple_int_command( conn, "admin", "ismaster", 1, out ) == MONGO_OK ) {
+        if( bson_find( it, out, "ismaster" ) )
+            ismaster = bson_iterator_bool( it );
 
-    if ( mongo_simple_int_command( conn, "admin", "ismaster", 1, &out ) == MONGO_OK ) {
-        if( bson_find( &it, &out, "ismaster" ) )
-            ismaster = bson_iterator_bool( &it );
-
-        if( bson_find( &it, &out, "maxBsonObjectSize" ) )
-            max_bson_size = bson_iterator_int( &it );
+        if( bson_find( it, out, "maxBsonObjectSize" ) )
+            max_bson_size = bson_iterator_int( it );
         conn->max_bson_size = max_bson_size;
 
-        if( bson_find( &it, &out, "setName" ) ) {
-            set_name = bson_iterator_string( &it );
+        if( bson_find( it, out, "setName" ) ) {
+            set_name = bson_iterator_string( it );
             if( strcmp( set_name, conn->replica_set->name ) != 0 ) {
-                bson_destroy( &out );
+                bson_destroy( out );
                 conn->err = MONGO_CONN_BAD_SET_NAME;
                 return MONGO_ERROR;
             }
         }
     }
 
-    bson_destroy( &out );
+    bson_destroy( out );
 
     if( ismaster ) {
         conn->replica_set->primary_connected = 1;
@@ -783,7 +776,7 @@ static int mongo_bson_valid( mongo *conn, const bson *bson, int write ) {
         }
     }
 
-    conn->err = 0;
+    conn->err = MONGO_CONN_SUCCESS;
 
     return MONGO_OK;
 }
@@ -807,29 +800,26 @@ static int mongo_cursor_bson_valid( mongo_cursor *cursor, const bson *bson ) {
 
 static int mongo_check_last_error( mongo *conn, const char *ns,
                                    mongo_write_concern *write_concern ) {
-    bson response = {NULL, 0};
-    bson_iterator it;
+    bson response[1];
+    bson_iterator it[1];
     int res = 0;
     char *cmd_ns = mongo_ns_to_cmd_db( ns );
 
-    res = mongo_find_one( conn, cmd_ns, write_concern->cmd, bson_shared_empty( ), &response );
+    res = mongo_find_one( conn, cmd_ns, write_concern->cmd, bson_shared_empty( ), response );
     bson_free( cmd_ns );
 
-    if ( res != MONGO_OK )
-        return MONGO_ERROR;
-
-    if( ( bson_find( &it, &response, "$err" ) == BSON_STRING ) ||
-            ( bson_find( &it, &response, "err" ) == BSON_STRING ) ) {
+    if (res == MONGO_OK &&
+        (bson_find( it, response, "$err" ) == BSON_STRING ||
+         bson_find( it, response, "err" ) == BSON_STRING)) {
 
         __mongo_set_error( conn, MONGO_WRITE_ERROR,
                            "See conn->lasterrstr for details.", 0 );
-        mongo_set_last_error( conn, &it, &response );
-        bson_destroy( &response );
-        return MONGO_ERROR;
+        mongo_set_last_error( conn, it, response );
+        res = MONGO_ERROR;
     }
 
-    bson_destroy( &response );
-    return MONGO_OK;
+    bson_destroy( response );
+    return res;
 }
 
 static int mongo_choose_write_concern( mongo *conn,
@@ -1311,25 +1301,21 @@ MONGO_EXPORT mongo_cursor *mongo_find( mongo *conn, const char *ns, const bson *
 
 MONGO_EXPORT int mongo_find_one( mongo *conn, const char *ns, const bson *query,
                                  const bson *fields, bson *out ) {
-
+    int ret;
     mongo_cursor cursor[1];
     mongo_cursor_init( cursor, conn, ns );
     mongo_cursor_set_query( cursor, query );
     mongo_cursor_set_fields( cursor, fields );
     mongo_cursor_set_limit( cursor, 1 );
 
-    if( mongo_cursor_next( cursor ) != MONGO_OK ) {
-        mongo_cursor_destroy( cursor );
-        return MONGO_ERROR;
-    }
-
-    if( out && bson_copy( out, &cursor->current ) != MONGO_OK ) {
-        mongo_cursor_destroy( cursor );
-        return MONGO_ERROR;
-    }
+    ret = mongo_cursor_next(cursor);
+    if (ret == MONGO_OK && out)
+        ret = bson_copy(out, &cursor->current);
+    if (ret != MONGO_OK)
+        bson_init_zero(out);
 
     mongo_cursor_destroy( cursor );
-    return MONGO_OK;
+    return ret;
 }
 
 MONGO_EXPORT void mongo_cursor_init( mongo_cursor *cursor, mongo *conn, const char *ns ) {
@@ -1511,110 +1497,104 @@ MONGO_EXPORT int mongo_create_index( mongo *conn, const char *ns, const bson *ke
 }
 
 MONGO_EXPORT bson_bool_t mongo_create_simple_index( mongo *conn, const char *ns, const char *field, int options, bson *out ) {
-    bson b;
+    bson b[1];
     bson_bool_t success;
 
-    bson_init( &b );
-    bson_append_int( &b, field, 1 );
-    bson_finish( &b );
+    bson_init( b );
+    bson_append_int( b, field, 1 );
+    bson_finish( b );
 
-    success = mongo_create_index( conn, ns, &b, NULL, options, out );
-    bson_destroy( &b );
+    success = mongo_create_index( conn, ns, b, NULL, options, out );
+    bson_destroy( b );
     return success;
 }
 
 MONGO_EXPORT int mongo_create_capped_collection( mongo *conn, const char *db,
         const char *collection, int size, int max, bson *out ) {
 
-    bson b;
+    bson b[1];
     int result;
 
-    bson_init( &b );
-    bson_append_string( &b, "create", collection );
-    bson_append_bool( &b, "capped", 1 );
-    bson_append_int( &b, "size", size );
+    bson_init( b );
+    bson_append_string( b, "create", collection );
+    bson_append_bool( b, "capped", 1 );
+    bson_append_int( b, "size", size );
     if( max > 0 )
-        bson_append_int( &b, "max", size );
-    bson_finish( &b );
+        bson_append_int( b, "max", size );
+    bson_finish( b );
 
-    result = mongo_run_command( conn, db, &b, out );
+    result = mongo_run_command( conn, db, b, out );
 
-    bson_destroy( &b );
+    bson_destroy( b );
 
     return result;
 }
 
 MONGO_EXPORT double mongo_count( mongo *conn, const char *db, const char *coll, const bson *query ) {
-    bson cmd;
-    bson out = {NULL, 0};
-    double count = -1;
+    bson cmd[1];
+    bson out[1];
+    double count = MONGO_ERROR;  // -1
 
-    bson_init( &cmd );
-    bson_append_string( &cmd, "count", coll );
+    bson_init( cmd );
+    bson_append_string( cmd, "count", coll );
     if ( query && bson_size( query ) > 5 ) /* not empty */
-        bson_append_bson( &cmd, "query", query );
-    bson_finish( &cmd );
+        bson_append_bson( cmd, "query", query );
+    bson_finish( cmd );
 
-    if( mongo_run_command( conn, db, &cmd, &out ) == MONGO_OK ) {
-        bson_iterator it;
-        if( bson_find( &it, &out, "n" ) )
-            count = bson_iterator_double( &it );
-        bson_destroy( &cmd );
-        bson_destroy( &out );
-        return count;
+    if( mongo_run_command( conn, db, cmd, out ) == MONGO_OK ) {
+        bson_iterator it[1];
+        if( bson_find( it, out, "n" ) )
+            count = bson_iterator_double( it );
     }
-    else {
-        bson_destroy( &out );
-        bson_destroy( &cmd );
-        return MONGO_ERROR;
-    }
+    bson_destroy( out );
+    bson_destroy( cmd );
+    return count;
 }
 
 MONGO_EXPORT int mongo_run_command( mongo *conn, const char *db, const bson *command,
                                     bson *out ) {
-    bson response = {NULL, 0};
-    bson_iterator it;
+    bson response[1];
+    bson_iterator it[1];
     size_t sl = strlen( db );
-    char *ns = bson_malloc( sl + 5 + 1 ); /* ".$cmd" + nul */
+    char *ns = (char*) bson_malloc( sl + 5 + 1 ); /* ".$cmd" + nul */
     int res = 0;
 
     strcpy( ns, db );
     strcpy( ns+sl, ".$cmd" );
 
-    res = mongo_find_one( conn, ns, command, bson_shared_empty( ), &response );
+    res = mongo_find_one( conn, ns, command, bson_shared_empty( ), response );
     bson_free( ns );
 
-    if( res != MONGO_OK )
-        return MONGO_ERROR;
-    
-    if( ! bson_find( &it, &response, "ok" ) ||
-        ! bson_iterator_bool( &it ) ) {
+    if (res == MONGO_OK && (!bson_find( it, response, "ok" ) || !bson_iterator_bool( it )) ) {
         conn->err = MONGO_COMMAND_FAILED;
-        bson_destroy( &response );
-        return MONGO_ERROR;
+        bson_destroy( response );
+        res = MONGO_ERROR;
     }
 
-    if( out )
-        *out = response;
-    else
-        bson_destroy( &response );
+    if (out)
+        if (res == MONGO_OK)
+            *out = *response;
+        else
+            bson_init_zero(out);
+    else if (res == MONGO_OK)
+        bson_destroy(response);
 
-    return MONGO_OK;
+    return res;
 }
 
 MONGO_EXPORT int mongo_simple_int_command( mongo *conn, const char *db,
         const char *cmdstr, int arg, bson *out ) {
 
-    bson cmd;
+    bson cmd[1];
     int result;
 
-    bson_init( &cmd );
-    bson_append_int( &cmd, cmdstr, arg );
-    bson_finish( &cmd );
+    bson_init( cmd );
+    bson_append_int( cmd, cmdstr, arg );
+    bson_finish( cmd );
 
-    result = mongo_run_command( conn, db, &cmd, out );
+    result = mongo_run_command( conn, db, cmd, out );
 
-    bson_destroy( &cmd );
+    bson_destroy( cmd );
 
     return result;
 }
@@ -1650,23 +1630,24 @@ MONGO_EXPORT void mongo_cmd_reset_error( mongo *conn, const char *db ) {
 static int mongo_cmd_get_error_helper( mongo *conn, const char *db,
                                        bson *realout, const char *cmdtype ) {
 
-    bson out = {NULL,0};
+    bson out[1];
     bson_bool_t haserror = 0;
 
     /* Reset last error codes. */
     mongo_clear_errors( conn );
+    bson_init_zero(out);
 
     /* If there's an error, store its code and string in the connection object. */
-    if( mongo_simple_int_command( conn, db, cmdtype, 1, &out ) == MONGO_OK ) {
-        bson_iterator it;
-        haserror = ( bson_find( &it, &out, "err" ) != BSON_NULL );
-        if( haserror ) mongo_set_last_error( conn, &it, &out );
+    if( mongo_simple_int_command( conn, db, cmdtype, 1, out ) == MONGO_OK ) {
+        bson_iterator it[1];
+        haserror = ( bson_find( it, out, "err" ) != BSON_NULL );
+        if( haserror ) mongo_set_last_error( conn, it, out );
     }
 
     if( realout )
-        *realout = out; /* transfer of ownership */
+        *realout = *out; /* transfer of ownership */
     else
-        bson_destroy( &out );
+        bson_destroy( out );
 
     if( haserror )
         return MONGO_ERROR;
@@ -1683,19 +1664,20 @@ MONGO_EXPORT int mongo_cmd_get_last_error( mongo *conn, const char *db, bson *ou
 }
 
 MONGO_EXPORT bson_bool_t mongo_cmd_ismaster( mongo *conn, bson *realout ) {
-    bson out = {NULL,0};
+    bson out[1];
     bson_bool_t ismaster = 0;
 
-    if ( mongo_simple_int_command( conn, "admin", "ismaster", 1, &out ) == MONGO_OK ) {
-        bson_iterator it;
-        bson_find( &it, &out, "ismaster" );
-        ismaster = bson_iterator_bool( &it );
-    }
-
-    if( realout )
-        *realout = out; /* transfer of ownership */
-    else
-        bson_destroy( &out );
+    int res = mongo_simple_int_command( conn, "admin", "ismaster", 1, out );
+    if (res == MONGO_OK) {
+        bson_iterator it[1];
+        bson_find( it, out, "ismaster" );
+        ismaster = bson_iterator_bool( it );
+        if (realout)
+            *realout = *out; /* transfer of ownership */
+        else
+            bson_destroy( out );
+    } else if (realout)
+        bson_init_zero(realout);
 
     return ismaster;
 }

--- a/src/mongo.h
+++ b/src/mongo.h
@@ -692,9 +692,29 @@ MONGO_EXPORT double mongo_count( mongo *conn, const char *db, const char *coll,
  * @param out a bson document containing errors, if any.
  *
  * @return MONGO_OK if index is created successfully; otherwise, MONGO_ERROR.
+ *
+ * @note May not return bson data when returning MONGO_ERROR,
+ *       Use bson_has_data() on the returned 'out' for determining this.
  */
 MONGO_EXPORT int mongo_create_index( mongo *conn, const char *ns, const bson *key,
                                      const char *name, int options, bson *out );
+
+/**
+ * Create an index with a single key.
+ *
+ * @param conn a mongo object.
+ * @param ns the namespace.
+ * @param field the index key.
+ * @param options index options.
+ * @param out a BSON document containing errors, if any.
+ *
+ * @return true if the index was created.
+ *
+ * @note May not return bson data when returning MONGO_ERROR,
+ *       Use bson_has_data() on the returned 'out' for determining this.
+ */
+MONGO_EXPORT bson_bool_t mongo_create_simple_index( mongo *conn, const char *ns,
+        const char *field, int options, bson *out );
 
 /**
  * Create a capped collection.
@@ -710,20 +730,6 @@ MONGO_EXPORT int mongo_create_index( mongo *conn, const char *ns, const bson *ke
  */
 MONGO_EXPORT int mongo_create_capped_collection( mongo *conn, const char *db,
         const char *collection, int size, int max, bson *out );
-
-/**
- * Create an index with a single key.
- *
- * @param conn a mongo object.
- * @param ns the namespace.
- * @param field the index key.
- * @param options index options.
- * @param out a BSON document containing errors, if any.
- *
- * @return true if the index was created.
- */
-MONGO_EXPORT bson_bool_t mongo_create_simple_index( mongo *conn, const char *ns,
-        const char *field, int options, bson *out );
 
 /**
  * Run a command on a MongoDB server.
@@ -837,6 +843,9 @@ MONGO_EXPORT bson_bool_t mongo_cmd_ismaster( mongo *conn, bson *out );
  *
  * @return MONGO_OK if no error and MONGO_ERROR on error. On error, check the values
  *     of conn->lasterrcode and conn->lasterrstr for the error status.
+ *
+ * @note May not return bson data when returning MONGO_ERROR,
+ *       Use bson_has_data() on the returned 'out' for determining this.
  */
 MONGO_EXPORT int mongo_cmd_get_last_error( mongo *conn, const char *db, bson *out );
 
@@ -849,6 +858,9 @@ MONGO_EXPORT int mongo_cmd_get_last_error( mongo *conn, const char *db, bson *ou
  *
  * @return MONGO_OK if no error and MONGO_ERROR on error. On error, check the values
  *     of conn->lasterrcode and conn->lasterrstr for the error status.
+ *
+ * @note May not return bson data when returning MONGO_ERROR,
+ *       Use bson_has_data() on the returned 'out' for determining this.
  */
 MONGO_EXPORT int mongo_cmd_get_prev_error( mongo *conn, const char *db, bson *out );
 


### PR DESCRIPTION
I have attempted to address the initialization problems in an efficient manner.

 _bson_zero() was renamed to bson_init_zero() and made public (so mongo.c can call it); otherwise, it is a convenience function for the paranoid.  ;)  I moved the stack to the end of the bson struct so bson_init_zero() can clear everything but that easily.

mongo_find_one() was fixed so that it calls bson_init_zero() if it doesn't otherwise return a bson.  This solved a lot of problems as use of this function is widespread.

Unnecessary initializers have been dropped.

mongo_get_error_helper() now also calls bson_init_zero().   After calling those functions that depend on it { mongo_create_index(), mongo_create_simple_index(),
   mongo_cmd_get_last_error() and mongo_cmd_get_prev_error() },
one should call bson_has_data() to see if the function really returned an error bson.

Small syntax and logic fixes as I went.  Some formatting in gridfs.c  I really can't read the stuff with a bunch of extra braces thrown in.  Deeper indenting would help too.

This compiles, but I have not tested it.  Can someone help me with this part?  My drivers are a bit out of date with mongo-c-driver as is.  Next project I suppose is to these catch up.
