### PR TITLE
Small refactoring to mongo_find_one to remove duplicated code

### DIFF
--- a/src/mongo.c
+++ b/src/mongo.c
@@ -1319,7 +1319,7 @@ MONGO_EXPORT int mongo_find_one( mongo *conn, const char *ns, const bson *query,
     mongo_cursor_set_fields( cursor, fields );
     mongo_cursor_set_limit( cursor, 1 );
 
-    if( mongo_cursor_next( cursor ) != MONGO_OK ) errors_exists = 1;    
+    errors_exists = ( mongo_cursor_next( cursor ) != MONGO_OK );    
 
     if( !errors_exists && out && bson_copy( out, &cursor->current ) != MONGO_OK ) errors_exists = 1;           
 

--- a/src/mongo.c
+++ b/src/mongo.c
@@ -1312,24 +1312,19 @@ MONGO_EXPORT mongo_cursor *mongo_find( mongo *conn, const char *ns, const bson *
 MONGO_EXPORT int mongo_find_one( mongo *conn, const char *ns, const bson *query,
                                  const bson *fields, bson *out ) {
 
+    int errors_exists = 0;
     mongo_cursor cursor[1];
     mongo_cursor_init( cursor, conn, ns );
     mongo_cursor_set_query( cursor, query );
     mongo_cursor_set_fields( cursor, fields );
     mongo_cursor_set_limit( cursor, 1 );
 
-    if( mongo_cursor_next( cursor ) != MONGO_OK ) {
-        mongo_cursor_destroy( cursor );
-        return MONGO_ERROR;
-    }
+    if( mongo_cursor_next( cursor ) != MONGO_OK ) errors_exists = 1;    
 
-    if( out && bson_copy( out, &cursor->current ) != MONGO_OK ) {
-        mongo_cursor_destroy( cursor );
-        return MONGO_ERROR;
-    }
+    if( !errors_exists && out && bson_copy( out, &cursor->current ) != MONGO_OK ) errors_exists = 1;           
 
     mongo_cursor_destroy( cursor );
-    return MONGO_OK;
+    return errors_exists ? MONGO_ERROR : MONGO_OK;
 }
 
 MONGO_EXPORT void mongo_cursor_init( mongo_cursor *cursor, mongo *conn, const char *ns ) {


### PR DESCRIPTION
Small refactoring suggested with co-worker @AugustoPedraza to remove code duplication on mongo_find_one()
