### PR TITLE
Fix hostname length issue

### DIFF
--- a/src/mongo.c
+++ b/src/mongo.c
@@ -436,7 +436,7 @@ MONGO_EXPORT int mongo_client( mongo *conn , const char *host, int port ) {
     mongo_init( conn );
 
     conn->primary = (mongo_host_port*)bson_malloc( sizeof( mongo_host_port ) );
-    strncpy( conn->primary->host, host, strlen( host ) + 1 );
+    snprintf( conn->primary->host, MAXHOSTNAMELEN, "%s", host);
     conn->primary->port = port;
     conn->primary->next = NULL;
 
@@ -478,7 +478,7 @@ static void mongo_replica_set_add_node( mongo_host_port **list, const char *host
     mongo_host_port *host_port = (mongo_host_port*)bson_malloc( sizeof( mongo_host_port ) );
     host_port->port = port;
     host_port->next = NULL;
-    strncpy( host_port->host, host, strlen( host ) + 1 );
+    snprintf( host_port->host, MAXHOSTNAMELEN, "%s", host);
 
     if( *list == NULL )
         *list = host_port;
@@ -661,7 +661,7 @@ MONGO_EXPORT int mongo_replica_set_client( mongo *conn ) {
                 /* Primary found, so return. */
                 else if( conn->replica_set->primary_connected ) {
                     conn->primary = bson_malloc( sizeof( mongo_host_port ) );
-                    strncpy( conn->primary->host, node->host, strlen( node->host ) + 1 );
+                    snprintf( conn->primary->host, MAXHOSTNAMELEN, "%s", node->host );
                     conn->primary->port = node->port;
                     return MONGO_OK;
                 }

--- a/src/mongo.h
+++ b/src/mongo.h
@@ -45,6 +45,10 @@ MONGO_EXTERN_C_START
 
 #define MONGO_ERR_LEN 128
 
+#ifndef MAXHOSTNAMELEN
+    #define MAXHOSTNAMELEN 256
+#endif
+
 typedef enum mongo_error_t {
     MONGO_CONN_SUCCESS = 0,  /**< Connection success! */
     MONGO_CONN_NO_SOCKET,    /**< Could not create a socket. */
@@ -145,7 +149,7 @@ typedef struct {
 #pragma pack()
 
 typedef struct mongo_host_port {
-    char host[255];
+    char host[MAXHOSTNAMELEN];
     int port;
     struct mongo_host_port *next;
 } mongo_host_port;


### PR DESCRIPTION
The length of the hostname in some platforms can be larger than 255 bytes.
And I don't want to include those header files which define the max hostname length in current platform,so simply define a new MACRO to finish this job.
