### PR TITLE
Add test case for bson_oid_generated_time

### DIFF
--- a/test/bson_test.c
+++ b/test/bson_test.c
@@ -330,12 +330,28 @@ int test_bson_deep_nesting( void ) {
     return 0;
 }
 
+int test_bson_oid_generated_time( void ) {
+    time_t cur_time;
+    bson_oid_t oid;
+
+    printf("\nsizeof(time_t) is %lu\n\n", (long unsigned) sizeof(time_t));
+
+    cur_time = time ( NULL );
+    bson_oid_gen(&oid);
+
+    ASSERT( bson_oid_generated_time(&oid) >= cur_time );
+    ASSERT( bson_oid_generated_time(&oid) < cur_time + 1 );
+
+    return 0;
+}
+
 int main() {
 
   test_bson_generic();
   test_bson_iterator();
   test_bson_size();
   test_bson_deep_nesting();
+  test_bson_oid_generated_time();
 
   return 0;
 }


### PR DESCRIPTION
This should always pass, and does on my system.

There's a bug https://jira.mongodb.org/browse/CDRIVER-195 which is an under-initialization problem. This test case unfortunately doesn't catch it. Since the bug depends on there being garbage on the stack, I don't know how to write a test case that will always fail.
