### PR TITLE
Fixed crash caused by wrong chunkSize read

### DIFF
--- a/src/gridfs.c
+++ b/src/gridfs.c
@@ -628,8 +628,13 @@ MONGO_EXPORT int gridfile_get_chunksize( const gridfile *gfile ) {
     return gfile->chunkSize;
   } else {
     if( bson_find(&it, gfile->meta, "chunkSize") != BSON_EOO ) {
-      return bson_iterator_int(&it);
-  } else {  
+      int size = bson_iterator_int(&it);
+      if(size) {
+        return size;
+      } else {
+        return DEFAULT_CHUNK_SIZE;
+      }
+    } else {
       return DEFAULT_CHUNK_SIZE;
     }
   }


### PR DESCRIPTION
With wrong chunkSize written and read, there is a crash may raised in function gridfile_read_buffer() at line:

``` c
  first_chunk = (int)((gfile->pos) / chunksize);  
```

when chunkSize is 0.

This commit fixed problem by avoid return 0 in gridfile_get_chunksize()
