### PR TITLE
Update benchmark_test.c for new function interface

### DIFF
--- a/test/benchmark_test.c
+++ b/test/benchmark_test.c
@@ -178,7 +178,7 @@ static void index_insert_large_test( void ) {
 static void batch_insert_small_test( void ) {
     int i, j;
     bson b[BATCH_SIZE];
-    bson *bp[BATCH_SIZE];
+    const bson *bp[BATCH_SIZE];
     for ( j=0; j < BATCH_SIZE; j++ )
         bp[j] = &b[j];
 
@@ -196,7 +196,7 @@ static void batch_insert_small_test( void ) {
 static void batch_insert_medium_test( void ) {
     int i, j;
     bson b[BATCH_SIZE];
-    bson *bp[BATCH_SIZE];
+    const bson *bp[BATCH_SIZE];
     for ( j=0; j < BATCH_SIZE; j++ )
         bp[j] = &b[j];
 
@@ -214,7 +214,7 @@ static void batch_insert_medium_test( void ) {
 static void batch_insert_large_test( void ) {
     int i, j;
     bson b[BATCH_SIZE];
-    bson *bp[BATCH_SIZE];
+    const bson *bp[BATCH_SIZE];
     for ( j=0; j < BATCH_SIZE; j++ )
         bp[j] = &b[j];
 

--- a/test/benchmark_test.c
+++ b/test/benchmark_test.c
@@ -186,7 +186,7 @@ static void batch_insert_small_test( void ) {
         for ( j=0; j < BATCH_SIZE; j++ )
             make_small( &b[j], i );
 
-        mongo_insert_batch( conn, DB ".batch.small", bp, BATCH_SIZE, NULL );
+        mongo_insert_batch( conn, DB ".batch.small", bp, BATCH_SIZE, NULL, 0 );
 
         for ( j=0; j < BATCH_SIZE; j++ )
             bson_destroy( &b[j] );
@@ -204,7 +204,7 @@ static void batch_insert_medium_test( void ) {
         for ( j=0; j < BATCH_SIZE; j++ )
             make_medium( &b[j], i );
 
-        mongo_insert_batch( conn, DB ".batch.medium", bp, BATCH_SIZE, NULL );
+        mongo_insert_batch( conn, DB ".batch.medium", bp, BATCH_SIZE, NULL, 0 );
 
         for ( j=0; j < BATCH_SIZE; j++ )
             bson_destroy( &b[j] );
@@ -222,7 +222,7 @@ static void batch_insert_large_test( void ) {
         for ( j=0; j < BATCH_SIZE; j++ )
             make_large( &b[j], i );
 
-        mongo_insert_batch( conn, DB ".batch.large", bp, BATCH_SIZE, NULL );
+        mongo_insert_batch( conn, DB ".batch.large", bp, BATCH_SIZE, NULL, 0 );
 
         for ( j=0; j < BATCH_SIZE; j++ )
             bson_destroy( &b[j] );
@@ -384,13 +384,13 @@ static void clean( void ) {
     }
 
     /* create the db */
-    mongo_insert( conn, DB ".creation", bson_empty( &b ), NULL );
+    mongo_insert( conn, DB ".creation", bson_shared_empty(), NULL );
     ASSERT( !mongo_cmd_get_last_error( conn, DB, NULL ) );
 }
 
 int main() {
     INIT_SOCKETS_FOR_WINDOWS;
-    CONN_CONNECT_TEST;
+    CONN_CLIENT_TEST;
 
     clean();
 


### PR DESCRIPTION
I have try to compile benchmark_test.c and found it was a little out of date so that cannot be compiled.
Then I make some modification on it and it work now.

When compile with gcc (V4.6.3), there were 3 warnings:

> benchmark_test.c: In function ‘batch_insert_small_test’:
> benchmark_test.c:189:9: warning: passing argument 3 of ‘mongo_insert_batch’ from incompatible pointer type [enabled by default]
> /home/newk/repo/mongo-c-driver/src/mongo.h:471:18: note: expected ‘const struct bson *_’ but argument is of type ‘struct bson *_’
> benchmark_test.c: In function ‘batch_insert_medium_test’:
> benchmark_test.c:207:9: warning: passing argument 3 of ‘mongo_insert_batch’ from incompatible pointer type [enabled by default]
> /home/newk/repo/mongo-c-driver/src/mongo.h:471:18: note: expected ‘const struct bson *_’ but argument is of type ‘struct bson *_’
> benchmark_test.c: In function ‘batch_insert_large_test’:
> benchmark_test.c:225:9: warning: passing argument 3 of ‘mongo_insert_batch’ from incompatible pointer type [enabled by default]
> /home/newk/repo/mongo-c-driver/src/mongo.h:471:18: note: expected ‘const struct bson *_’ but argument is of type ‘struct bson *_’

I have no idea how to deal with them, any suggestion?
