### PR TITLE
mongo_create_index is expected to return a bson object in case of errors

### DIFF
--- a/src/mongo.c
+++ b/src/mongo.c
@@ -1498,11 +1498,15 @@ MONGO_EXPORT int mongo_create_index( mongo *conn, const char *ns, const bson *ke
     p = strchr( idxns, '.' );
     if ( !p ) {
 	    bson_destroy( &b );
+        if( out )
+            bson_init_zero(out);
 	    return MONGO_ERROR;
     }
     strcpy( p, ".system.indexes" );
     if ( mongo_insert( conn, idxns, &b, NULL ) != MONGO_OK) {
 	    bson_destroy( &b );
+        if( out )
+            bson_init_zero(out);
 	    return MONGO_ERROR;
     }
     bson_destroy( &b );


### PR DESCRIPTION
The behavior is described in the header comment and matches the contract of mongo_cmd_get_last_error. Callers should use bson_has_data(.) to check.

This avoids a segfault in my code which was caused by these new checks in 1abad57.
