### PR TITLE
if we call mongo_cursor_next() for the first time and there is no result, we should return MONGO_CURSOR_EXHAUSTED

### DIFF
--- a/src/mongo.c
+++ b/src/mongo.c
@@ -1387,6 +1387,7 @@ MONGO_EXPORT int mongo_cursor_next( mongo_cursor *cursor ) {
             if( already_sent ) {
                 cursor->err = MONGO_CURSOR_INVALID;
             }
+            /* else preserve the MONGO_CURSOR_EXHAUSTED error flag set by mongo_cursor_get_more */
             return MONGO_ERROR;
         }
     }

--- a/src/mongo.c
+++ b/src/mongo.c
@@ -1361,10 +1361,11 @@ MONGO_EXPORT const bson *mongo_cursor_bson( mongo_cursor *cursor ) {
 MONGO_EXPORT int mongo_cursor_next( mongo_cursor *cursor ) {
     char *next_object;
     char *message_end;
+    int already_sent = ( cursor->flags & MONGO_CURSOR_QUERY_SENT ) == MONGO_CURSOR_QUERY_SENT;
 
     if( cursor == NULL ) return MONGO_ERROR;
 
-    if( ! ( cursor->flags & MONGO_CURSOR_QUERY_SENT ) )
+    if( ! already_sent )
         if( mongo_cursor_op_query( cursor ) != MONGO_OK )
             return MONGO_ERROR;
 
@@ -1383,7 +1384,9 @@ MONGO_EXPORT int mongo_cursor_next( mongo_cursor *cursor ) {
         }
 
         else {
-            cursor->err = MONGO_CURSOR_INVALID;
+            if( already_sent ) {
+                cursor->err = MONGO_CURSOR_INVALID;
+            }
             return MONGO_ERROR;
         }
     }


### PR DESCRIPTION
As far as I understand, it is possible to create my own cursor, with:
mongo_cursor_init()
mongo_cursor_set_query()
mongo_cursor_set_skip()
mongo_cursor_set_limit()
mongo_cursor_set_options()

In that case, to run for the first time the cursor, I use directly:
mongo_cursor_next()

But if the cursor returns no result, with this commit: 2bed7e5 I don't get anymore MONGO_CURSOR_EXHAUSTED in the cursor error.
