### PR TITLE
mongo_create_index: Add docs for ttl parameter, indicate -1 as a default, and pass through a 0

### DIFF
--- a/src/mongo.c
+++ b/src/mongo.c
@@ -1499,7 +1499,7 @@ MONGO_EXPORT int mongo_create_index( mongo *conn, const char *ns, const bson *ke
     if ( options & MONGO_INDEX_SPARSE )
         bson_append_bool( &b, "sparse", 1 );
 	
-    if( ttl > 0 )
+    if( ttl >= 0 )
         bson_append_int( &b, "expireAfterSeconds", ttl );
 
     bson_finish( &b );

--- a/src/mongo.h
+++ b/src/mongo.h
@@ -693,6 +693,9 @@ MONGO_EXPORT double mongo_count( mongo *conn, const char *db, const char *coll,
  * @param options a bitfield for setting index options. Possibilities include
  *   MONGO_INDEX_UNIQUE, MONGO_INDEX_DROP_DUPS, MONGO_INDEX_BACKGROUND,
  *   and MONGO_INDEX_SPARSE.
+ * @ttl Pass -1 to create a normal index. If >= 0, this will be a TTL index,
+ *   and mongo will automatically remove documents from the collection.
+ *   See http://docs.mongodb.org/manual/tutorial/expire-data/
  * @param out a bson document containing errors, if any.
  *
  * @return MONGO_OK if index is created successfully; otherwise, MONGO_ERROR.


### PR DESCRIPTION
This commit is somewhat dangerous if users (like me) were passing a 0, but it fills out the API and at least documents what to do.
