### PR TITLE
Removed call to mongo_cursor_destroy() when call to mongo_message_send() fails

### DIFF
--- a/src/mongo.c
+++ b/src/mongo.c
@@ -1268,8 +1268,7 @@ static int mongo_cursor_get_more( mongo_cursor *cursor ) {
 
         bson_free( cursor->reply );
         res = mongo_message_send( cursor->conn, mm );
-        if( res != MONGO_OK ) {
-            mongo_cursor_destroy( cursor );
+        if( res != MONGO_OK ) {            
             return MONGO_ERROR;
         }
 


### PR DESCRIPTION
Removed call to mongo_cursor_destroy() when call to mongo_message_send() fails fails with value != than MONGO_OK with the purpose of delegating responsability of destroying the cursor to the consumer of the cursor.

See the next lines:
 res = mongo_read_response( cursor->conn, &( cursor->reply ) );
        if( res != MONGO_OK )
            return MONGO_ERROR;

Semantically the developer will probably program his/her code to destroy the cursor upon receiving a  MONGO_ERROR return value. But how the code was before, it will receive a  MONGO_ERROR without having a clear way of knowing that the cursor was destroyed.
I think we need this change to keep consistent semantics on object lifecycle management. Let the user create/destroy the cursor
