### PR TITLE
Fixed access violation when killing primary replica

### DIFF
--- a/src/mongo.c
+++ b/src/mongo.c
@@ -1048,7 +1048,7 @@ MONGO_EXPORT void mongo_write_concern_init( mongo_write_concern *write_concern )
 MONGO_EXPORT int mongo_write_concern_finish( mongo_write_concern *write_concern ) {
     bson *command;
 
-    /* Destory any existing serialized write concern object and reuse it. */
+    /* Destroy any existing serialized write concern object and reuse it. */
     if( write_concern->cmd ) {
         bson_destroy( write_concern->cmd );
         command = write_concern->cmd;
@@ -1266,7 +1266,11 @@ static int mongo_cursor_get_more( mongo_cursor *cursor ) {
         data = mongo_data_append32( data, &limit );
         mongo_data_append64( data, &cursor->reply->fields.cursorID );
 
-        bson_free( cursor->reply );
+        if( cursor->reply )
+        {
+          bson_free( cursor->reply );
+          cursor->reply = NULL;
+        }
         res = mongo_message_send( cursor->conn, mm );
         if( res != MONGO_OK ) {
             mongo_cursor_destroy( cursor );
@@ -1451,7 +1455,7 @@ MONGO_EXPORT int mongo_cursor_destroy( mongo_cursor *cursor ) {
         result = mongo_message_send( conn, mm );
     }
 
-    bson_free( cursor->reply );
+    if( cursor->reply ) bson_free( cursor->reply );
     bson_free( ( void * )cursor->ns );
 
     if( cursor->flags & MONGO_CURSOR_MUST_FREE )


### PR DESCRIPTION
In a situation of heavy traffic reading from a capped collection if a primary node on a replicaset is killed driver is left with a reply pointer in cursor object with a dangling pointer.

This piece of code:

```
...
        data = mongo_data_append( data, cursor->ns, sl );
        data = mongo_data_append32( data, &limit );
        mongo_data_append64( data, &cursor->reply->fields.cursorID );

        bson_free( cursor->reply ); /* This creates dangling pointer */

        res = mongo_message_send( cursor->conn, mm ); /* This operation fails when primary is dead, leaving cursor->reply dangling */
        if( res != MONGO_OK ) {
            mongo_cursor_destroy( cursor );
            return MONGO_ERROR;
        }
...
```

Needs to be changed to avoid dangling pointer.
