### PR TITLE
Fixed access violation when killing primary replica during heaving cursor reading

### DIFF
--- a/src/mongo.c
+++ b/src/mongo.c
@@ -1266,7 +1266,11 @@ static int mongo_cursor_get_more( mongo_cursor *cursor ) {
         data = mongo_data_append32( data, &limit );
         mongo_data_append64( data, &cursor->reply->fields.cursorID );
 
-        bson_free( cursor->reply );
+        if( cursor->reply )
+        {
+          bson_free( cursor->reply );
+          cursor->reply = NULL;
+        }
         res = mongo_message_send( cursor->conn, mm );
         if( res != MONGO_OK ) {
             mongo_cursor_destroy( cursor );
@@ -1451,7 +1455,7 @@ MONGO_EXPORT int mongo_cursor_destroy( mongo_cursor *cursor ) {
         result = mongo_message_send( conn, mm );
     }
 
-    bson_free( cursor->reply );
+    if( cursor->reply ) bson_free( cursor->reply );
     bson_free( ( void * )cursor->ns );
 
     if( cursor->flags & MONGO_CURSOR_MUST_FREE )


### PR DESCRIPTION
When using a capped collection to read heavily objects inserted at fast pace, the modified operation of destoying the reply buffer on the cursor ends up generating a dangling pointer that finished in an access violation the next time that bson_free( cursor->reply ) is called.

The code I post here fixed the issue, but maybe we should consider adding a little static function to manage the reply field on the cursor object.

Something like:

```
static void cursor_deleteReply( cursor _this )
{
  bson_free( _this->reply );
  _this->reply = NULL;
}
```

We should also call that function from the cursor destructor method.
