### PR TITLE
Added function `bson_init_finished_data_size` with size check for buffer

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -90,6 +90,21 @@ int bson_init_finished_data( bson *b, char *data, bson_bool_t ownsData ) {
     return BSON_OK;
 }
 
+int bson_init_finished_data_size( bson *b, char *data, int dataSize, bson_bool_t ownsData ) {
+    // check size
+    if ( dataSize < 4 ) { // 32 bits for size
+        return BSON_ERROR;
+    }
+
+    int bsonDataSize = bson_finished_data_size( data );
+    if ( bsonDataSize > dataSize ) {
+        return BSON_ERROR;
+    }
+
+    // pass to classic initializer
+    return bson_init_finished_data(b, data, ownsData);
+}
+
 int bson_init_finished_data_with_copy( bson *b, const char *data ) {
     int dataSize = bson_finished_data_size( data );
     if ( bson_init_size( b, dataSize ) == BSON_ERROR ) return BSON_ERROR;

--- a/src/bson.h
+++ b/src/bson.h
@@ -213,6 +213,23 @@ MONGO_EXPORT void bson_dealloc( bson* b );
 MONGO_EXPORT int bson_init_finished_data( bson *b, char *data, bson_bool_t ownsData );
 
 /**
+ * Initialize a BSON object for reading and set its data
+ * pointer to the provided char*. Additionaly do size check for
+ * data buffer.
+ *
+ * @note When done using the bson object, you must pass
+ *      the object to bson_destroy( ).
+ *
+ * @param b the BSON object to initialize.
+ * @param data the finalized raw BSON data.
+ * @param dataSize the size of data buffer (BSON object size must be less or equals to it)
+ * @param ownsData when true, bson_destroy() will free the data block.
+ *
+ * @return BSON_OK or BSON_ERROR.
+ */
+MONGO_EXPORT int bson_init_finished_data_size( bson *b, char *data, int dataSize, bson_bool_t ownsData );
+
+/**
  * Initialize a BSON object for reading and copy finalized
  * BSON data from the provided char*.
  *

--- a/test/bson_alloc_test.c
+++ b/test/bson_alloc_test.c
@@ -94,6 +94,32 @@ int test_bson_init_finished( void ) {
     return 0;
 }
 
+int test_bson_init_finished_size( void ) {
+    bson b;
+    ALLOW_AND_REQUIRE_MALLOC_BEGIN;
+    bson_init( &b );
+    ALLOW_AND_REQUIRE_MALLOC_END;
+    bson_append_double( &b, "d", 3.14 );
+    bson_append_string( &b, "s", "hello" );
+    bson_finish( &b );
+
+    bson b2;
+    int res;
+    res = bson_init_finished_data_size( &b2, (char *) bson_data( &b ), bson_size( &b ), 0 );
+    ASSERT( res == MONGO_OK );
+    bson_destroy( &b2 );
+
+    res = bson_init_finished_data_size( &b2, (char *) bson_data( &b ), bson_size( &b ) + 1, 0 );
+    ASSERT( res == MONGO_OK );
+    bson_destroy( &b2 );
+
+    res = bson_init_finished_data_size( &b2, (char *) bson_data( &b ), bson_size( &b ) - 1, 0 );
+    ASSERT( res == MONGO_ERROR );
+    bson_destroy( &b2 );
+
+    return 0;
+}
+
 int main() {
   bson_malloc_func = malloc_for_tests;
   bson_realloc_func = realloc_for_tests;
@@ -101,6 +127,7 @@ int main() {
 
   test_bson_empty();
   test_bson_init_finished();
+  test_bson_init_finished_size();
 
   return 0;
 }


### PR DESCRIPTION
This function is necessary when reading BSON object from _external_ source, for example, from network datagram.
